### PR TITLE
Allow Taunt Footstools to High-Jump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wubor"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["WuBoy and Bor"]
 edition = "2018"
 


### PR DESCRIPTION
Before, taunt footstools would force a small jump. Now you can hold Taunt to jump higher.