### PR TITLE
Marth - 0.15.1

### DIFF
--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -531,7 +531,7 @@ pub mod marth {
             pub const DISABLE_STANCE_CHANGE : i32 = 0x1100;
             pub const ATTACK_3_CHANGE_MOTION : i32 = 0x1101;
             pub const ATTACK_F3_HEAVY : i32 = 0x1102;
-            pub const SPECIAL_S_FLASHING_BLADE : i32 = 0x1101;
+            pub const SPECIAL_S_ENABLE_SPECIALS : i32 = 0x1101;
             pub const SPECIAL_S_DASH : i32 = 0x1102;
             pub const SPECIAL_S_END : i32 = 0x1103;
             pub const SPECIAL_S2_FINAL_BLOW : i32 = 0x1104;

--- a/src/fighter/marth/acmd/stance_specials.rs
+++ b/src/fighter/marth/acmd/stance_specials.rs
@@ -21,7 +21,7 @@ unsafe fn marth_speciallwspecials(fighter: &mut L2CAgentBase) {
     }
     frame(fighter.lua_state_agent, 8.0);
     if macros::is_excute(fighter) {
-        VarModule::on_flag(fighter.battle_object, marth::status::flag::SPECIAL_S_FLASHING_BLADE);
+        VarModule::on_flag(fighter.battle_object, marth::status::flag::SPECIAL_S_ENABLE_SPECIALS);
     }
     macros::FT_MOTION_RATE(fighter, 0.5);
     frame(fighter.lua_state_agent, 16.0);
@@ -129,7 +129,7 @@ unsafe fn marth_speciallwspecialairs(fighter: &mut L2CAgentBase) {
     }
     frame(fighter.lua_state_agent, 8.0);
     if macros::is_excute(fighter) {
-        VarModule::on_flag(fighter.battle_object, marth::status::flag::SPECIAL_S_FLASHING_BLADE);
+        VarModule::on_flag(fighter.battle_object, marth::status::flag::SPECIAL_S_ENABLE_SPECIALS);
     }
     macros::FT_MOTION_RATE(fighter, 0.5);
     frame(fighter.lua_state_agent, 16.0);

--- a/src/fighter/marth/acmd/stance_specials.rs
+++ b/src/fighter/marth/acmd/stance_specials.rs
@@ -23,22 +23,22 @@ unsafe fn marth_speciallwspecials(fighter: &mut L2CAgentBase) {
     if macros::is_excute(fighter) {
         VarModule::on_flag(fighter.battle_object, marth::status::flag::SPECIAL_S_FLASHING_BLADE);
     }
+    macros::FT_MOTION_RATE(fighter, 0.5);
     frame(fighter.lua_state_agent, 16.0);
+    macros::FT_MOTION_RATE(fighter, 1.0);
     if macros::is_excute(fighter) {
         VarModule::on_flag(fighter.battle_object, marth::status::flag::SPECIAL_S_DASH);
     }
-    frame(fighter.lua_state_agent, 19.0);
+    frame(fighter.lua_state_agent, 18.0);
     if macros::is_excute(fighter) {
         macros::WHOLE_HIT(fighter, *HIT_STATUS_XLU);
     }
-    wait(fighter.lua_state_agent, 6.0);
-    if macros::is_excute(fighter) {
-        macros::WHOLE_HIT(fighter, *HIT_STATUS_NORMAL);
-    }
     frame(fighter.lua_state_agent, 27.0);
     if macros::is_excute(fighter) {
+        macros::WHOLE_HIT(fighter, *HIT_STATUS_NORMAL);
         VarModule::on_flag(fighter.battle_object, marth::status::flag::SPECIAL_S_END);
     }
+    macros::FT_MOTION_RATE(fighter, 0.5);
 }
 
 #[acmd_script( agent = "marth", script = "effect_speciallwspecials", category = ACMD_EFFECT, low_priority )]
@@ -131,22 +131,22 @@ unsafe fn marth_speciallwspecialairs(fighter: &mut L2CAgentBase) {
     if macros::is_excute(fighter) {
         VarModule::on_flag(fighter.battle_object, marth::status::flag::SPECIAL_S_FLASHING_BLADE);
     }
+    macros::FT_MOTION_RATE(fighter, 0.5);
     frame(fighter.lua_state_agent, 16.0);
+    macros::FT_MOTION_RATE(fighter, 1.0);
     if macros::is_excute(fighter) {
         VarModule::on_flag(fighter.battle_object, marth::status::flag::SPECIAL_S_DASH);
     }
-    frame(fighter.lua_state_agent, 19.0);
+    frame(fighter.lua_state_agent, 18.0);
     if macros::is_excute(fighter) {
         macros::WHOLE_HIT(fighter, *HIT_STATUS_XLU);
     }
-    wait(fighter.lua_state_agent, 6.0);
-    if macros::is_excute(fighter) {
-        macros::WHOLE_HIT(fighter, *HIT_STATUS_NORMAL);
-    }
     frame(fighter.lua_state_agent, 27.0);
     if macros::is_excute(fighter) {
+        macros::WHOLE_HIT(fighter, *HIT_STATUS_NORMAL);
         VarModule::on_flag(fighter.battle_object, marth::status::flag::SPECIAL_S_END);
     }
+    macros::FT_MOTION_RATE(fighter, 0.5);
 }
 
 #[acmd_script( agent = "marth", script = "effect_speciallwspecialairs", category = ACMD_EFFECT, low_priority )]
@@ -201,6 +201,12 @@ unsafe fn marth_speciallwspecialairs_exp(fighter: &mut L2CAgentBase) {
             *BATTLE_OBJECT_ID_INVALID as u32
         )
     }
+}
+
+#[acmd_script( agent = "marth", script = "game_speciallwspecials2start", category = ACMD_GAME, low_priority )]
+unsafe fn marth_speciallwspecials2start(fighter: &mut L2CAgentBase) {
+    frame(fighter.lua_state_agent, 1.0);
+    macros::FT_MOTION_RATE(fighter, 0.8);
 }
 
 #[acmd_script( agent = "marth", script = "effect_speciallwspecials2start", category = ACMD_EFFECT, low_priority )]
@@ -439,6 +445,12 @@ unsafe fn marth_speciallwspecials2end2_exp(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "marth", script = "game_speciallwspecialairs2start", category = ACMD_GAME, low_priority )]
+unsafe fn marth_speciallwspecialairs2start(fighter: &mut L2CAgentBase) {
+    frame(fighter.lua_state_agent, 1.0);
+    macros::FT_MOTION_RATE(fighter, 0.8);
+}
+
 #[acmd_script( agent = "marth", script = "effect_speciallwspecialairs2start", category = ACMD_EFFECT, low_priority )]
 unsafe fn marth_speciallwspecialairs2start_eff(fighter: &mut L2CAgentBase) {
     frame(fighter.lua_state_agent, 2.0);
@@ -653,7 +665,9 @@ unsafe fn marth_speciallwspecialhi(fighter: &mut L2CAgentBase) {
     if macros::is_excute(fighter) {
         macros::WHOLE_HIT(fighter, *HIT_STATUS_XLU);
     }
+    macros::FT_MOTION_RATE(fighter, 8.0 / 13.0);
     frame(fighter.lua_state_agent, 19.0);
+    macros::FT_MOTION_RATE(fighter, 1.0);
     if macros::is_excute(fighter) {
         macros::ATTACK(fighter, 0, 0, Hash40::new("top"), 12.0, 80, 30, 0, 120, 4.0, 0.0, 20.0, 12.0, Some(0.0), Some(7.5), Some(8.0), 1.4, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 25, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         macros::ATTACK(fighter, 1, 0, Hash40::new("top"), 12.0, 80, 30, 0, 120, 4.0, 0.0, 20.0, 12.0, Some(0.0), Some(7.5), Some(12.0), 1.4, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 25, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
@@ -735,10 +749,10 @@ pub fn install() {
     install_acmd_scripts!(
         marth_speciallwspecials, marth_speciallwspecials_eff, marth_speciallwspecials_snd, marth_speciallwspecials_exp,
         marth_speciallwspecialairs, marth_speciallwspecialairs_eff, marth_speciallwspecialairs_snd, marth_speciallwspecialairs_exp,
-        marth_speciallwspecials2start_eff, marth_speciallwspecials2start_snd, marth_speciallwspecials2start_exp,
+        marth_speciallwspecials2start, marth_speciallwspecials2start_eff, marth_speciallwspecials2start_snd, marth_speciallwspecials2start_exp,
         marth_speciallwspecials2loop, marth_speciallwspecials2loop_eff, marth_speciallwspecials2loop_snd, marth_speciallwspecials2loop_exp,
         marth_speciallwspecials2end2, marth_speciallwspecials2end2_eff, marth_speciallwspecials2end2_snd, marth_speciallwspecials2end2_exp,
-        marth_speciallwspecialairs2start_eff, marth_speciallwspecialairs2start_snd, marth_speciallwspecialairs2start_exp,
+        marth_speciallwspecialairs2start, marth_speciallwspecialairs2start_eff, marth_speciallwspecialairs2start_snd, marth_speciallwspecialairs2start_exp,
         marth_speciallwspecialairs2loop, marth_speciallwspecialairs2loop_eff, marth_speciallwspecialairs2loop_snd, marth_speciallwspecialairs2loop_exp,
         marth_speciallwspecialairs2end, marth_speciallwspecialairs2end_eff, marth_speciallwspecialairs2end_snd, marth_speciallwspecialairs2end_exp,
         marth_speciallwspecialhi, marth_speciallwspecialhi_eff, marth_speciallwspecialhi_snd, marth_speciallwspecialhi_exp

--- a/src/fighter/marth/status/stance_specials.rs
+++ b/src/fighter/marth/status/stance_specials.rs
@@ -257,10 +257,22 @@ unsafe extern "C" fn marth_speciallw_specials_main_loop(fighter: &mut L2CFighter
             );
         }
     }
-    if VarModule::is_flag(fighter.battle_object, marth::status::flag::SPECIAL_S_FLASHING_BLADE) {
-        if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) {
-            let status = CustomStatusModule::get_agent_status_kind(fighter.battle_object, marth::status::STANCE_SPECIAL_S2_START);
-            fighter.change_status(status.into(), false.into());
+    if VarModule::is_flag(fighter.battle_object, marth::status::flag::SPECIAL_S_ENABLE_SPECIALS) {
+        let cat1 = fighter.global_table[CMD_CAT1].get_i32();
+        if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0 {
+            VarModule::on_flag(fighter.battle_object, marth::instance::flag::IS_STANCE);
+            fighter.change_status(FIGHTER_STATUS_KIND_SPECIAL_HI.into(), true.into());
+            return 1.into();
+        }
+        let status = CustomStatusModule::get_agent_status_kind(fighter.battle_object, marth::status::STANCE_SPECIAL_S2_START);
+        if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_S != 0 {
+            VarModule::on_flag(fighter.battle_object, marth::instance::flag::IS_STANCE);
+            fighter.change_status(status.into(), true.into());
+            return 1.into();
+        }
+        if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_N != 0 {
+            VarModule::on_flag(fighter.battle_object, marth::instance::flag::IS_STANCE);
+            fighter.change_status(FIGHTER_STATUS_KIND_SPECIAL_LW.into(), true.into());
             return 1.into();
         }
     }

--- a/src/fighter/marth/status/stance_specials.rs
+++ b/src/fighter/marth/status/stance_specials.rs
@@ -346,6 +346,23 @@ unsafe extern "C" fn marth_speciallw_specials_dash_main_loop(fighter: &mut L2CFi
     if fighter.sub_transition_group_check_air_cliff().get_bool() {
         return 1.into();
     }
+    let cat1 = fighter.global_table[CMD_CAT1].get_i32();
+    if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0 {
+        VarModule::on_flag(fighter.battle_object, marth::instance::flag::IS_STANCE);
+        fighter.change_status(FIGHTER_STATUS_KIND_SPECIAL_HI.into(), true.into());
+        return 1.into();
+    }
+    let status = CustomStatusModule::get_agent_status_kind(fighter.battle_object, marth::status::STANCE_SPECIAL_S2_START);
+    if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_S != 0 {
+        VarModule::on_flag(fighter.battle_object, marth::instance::flag::IS_STANCE);
+        fighter.change_status(status.into(), true.into());
+        return 1.into();
+    }
+    if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_N != 0 {
+        VarModule::on_flag(fighter.battle_object, marth::instance::flag::IS_STANCE);
+        fighter.change_status(FIGHTER_STATUS_KIND_SPECIAL_LW.into(), true.into());
+        return 1.into();
+    }
     if StatusModule::is_situation_changed(fighter.module_accessor) {
         if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
             MotionModule::change_motion_inherit_frame(


### PR DESCRIPTION
Changelog:

Noble Side Special 1 - Close Call
- [x] Can no longer hold Special during startup to perform Flashing Blade.
- [x] Can now cancel into Noble Specials. Pressing Side Special will perform Flashing Blade instead of Close Call.
- [x] Dash startup reduced (16 > 12).
- [x] Dash Intangibility frames adjusted (3 - 9 > 2 - 11).
- [x] Endlag cut in half (numbers unknown).

Noble Side Special 2 - Flashing Blade
- [x] Startup reduced by 0.8x on both ground and air versions (numbers unknown).

Noble Up Special - Divine Fang
- [x] Startup reduced (19 > 14).