### PR TITLE
Revert Tech Input Changes + Increase Tech Window

### DIFF
--- a/src/fighter/common/common_status/damage_fall.rs
+++ b/src/fighter/common/common_status/damage_fall.rs
@@ -1,9 +1,8 @@
 use {
     smash::{
         lua2cpp::*,
-        hash40,
         phx::Vector3f,
-        app::{lua_bind::*, *},
+        app::lua_bind::*,
         lib::{lua_const::*, L2CValue}
     },
     wubor_utils::table_const::*
@@ -15,28 +14,21 @@ unsafe fn status_damagefall(fighter: &mut L2CFighterCommon) -> L2CValue {
     if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_GANON_SPECIAL_S_DAMAGE_FALL_AIR) {
         KineticModule::add_speed(fighter.module_accessor, &Vector3f {x: 1.25, y: 0.0, z: 0.0});
     }
-    fighter.sub_shift_status_main(L2CValue::Ptr(status_damagefall_main as *const () as _))
+    fighter.sub_shift_status_main(L2CValue::Ptr(L2CFighterCommon_status_DamageFall_Main as *const () as _))
 }
 
-unsafe extern "C" fn status_damagefall_main(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.sub_transition_group_check_air_cliff().get_bool()
-    || fighter.check_damage_fall_transition().get_bool() {
+#[skyline::hook(replace = L2CFighterCommon_status_DamageFall_Main)]
+unsafe fn status_damagefall_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.sub_transition_group_check_air_cliff().get_bool() {
         return 0.into();
     }
-    let tech = fighter.sub_check_passive_button(L2CValue::Void()).get_bool();
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_PASSIVE_FB)
-    && FighterUtil::is_touch_passive_ground(fighter.module_accessor, *GROUND_TOUCH_FLAG_DOWN as u32)
-    && WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("passive_fb_cont_value")) <= fighter.global_table[STICK_X].get_f32().abs()
-    && tech {
-        fighter.change_status(FIGHTER_STATUS_KIND_PASSIVE_FB.into(), true.into());
-        return true.into();
+    if fighter.sub_AirChkPassive().get_bool()
+    || fighter.sub_AirChkPassiveWall().get_bool()
+    || fighter.sub_AirChkPassiveWallJump().get_bool() {
+        return 0.into();
     }
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_PASSIVE)
-    && FighterUtil::is_touch_passive_ground(fighter.module_accessor, *GROUND_TOUCH_FLAG_DOWN as u32)
-    && !FighterStopModuleImpl::is_damage_stop(fighter.module_accessor)
-    && tech {
-        fighter.change_status(FIGHTER_STATUS_KIND_PASSIVE.into(), true.into());
-        return true.into();
+    if fighter.check_damage_fall_transition().get_bool() {
+        return 0.into();
     }
     if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_DOWN)
     && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
@@ -50,7 +42,8 @@ unsafe extern "C" fn status_damagefall_main(fighter: &mut L2CFighterCommon) -> L
 fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hooks!(
-            status_damagefall
+            status_damagefall,
+            status_damagefall_main
         );
     }
 }

--- a/src/fighter/common/common_status/escape.rs
+++ b/src/fighter/common/common_status/escape.rs
@@ -56,11 +56,10 @@ unsafe fn sub_escape_uniq_process_common_initstatus_common(fighter: &mut L2CFigh
                 );
             }
         }
-        if prev_status != *FIGHTER_STATUS_KIND_DAMAGE_FALL {
-            if prev_status == *FIGHTER_STATUS_KIND_TREAD_FALL {
-                WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_PREV_STATUS_PASSIVE_GROUND);
-            }
-            else if [
+        if prev_status != *FIGHTER_STATUS_KIND_DAMAGE_FALL
+        && prev_status != *FIGHTER_STATUS_KIND_TREAD_FALL {
+            if [
+                *FIGHTER_STATUS_KIND_DAMAGE_FLY,
                 *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
                 *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
                 *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,

--- a/src/fighter/common/common_status/escape_air.rs
+++ b/src/fighter/common/common_status/escape_air.rs
@@ -308,7 +308,8 @@ pub unsafe fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterCommon) 
     let passive_trigger_frame_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("passive_trigger_frame_mul"), 0);
     let passive_frame = air_escape_passive_trigger_frame as f32 * passive_trigger_frame_mul;
 
-    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_PREV_STATUS_PASSIVE_GROUND) {
+    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_PREV_STATUS_PASSIVE_GROUND)
+    || WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_PREV_STATUS_PASSIVE_AIR) {
         if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_PASSIVE_FB)
         && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
         && FighterUtil::is_touch_passive_ground(fighter.module_accessor, *GROUND_TOUCH_FLAG_DOWN as u32)
@@ -329,8 +330,6 @@ pub unsafe fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterCommon) 
             fighter.change_status(FIGHTER_STATUS_KIND_PASSIVE.into(), true.into());
             return 1.into();
         }
-    }
-    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_PREV_STATUS_PASSIVE_AIR) {
         if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_PASSIVE_WALL_JUMP_BUTTON)
         && FighterUtil::is_touch_passive_ground(fighter.module_accessor, (*GROUND_TOUCH_FLAG_LEFT | *GROUND_TOUCH_FLAG_RIGHT) as u32)
         && {

--- a/src/fighter/common/common_status/passive.rs
+++ b/src/fighter/common/common_status/passive.rs
@@ -25,31 +25,31 @@ pub unsafe fn is_bad_passive(fighter: &mut L2CFighterCommon) -> L2CValue {
     (weight + passive::invalid_passive_damage_add <= damage).into()
 }
 
-#[skyline::hook(replace = L2CFighterCommon_sub_check_passive_button)]
-unsafe fn sub_check_passive_button(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
-    // The basis of the new tech system, teching is now performed by having your stick tilted in
-    // any direction that *isn't* down, so neutral causes missed techs.
-    // This is also why that param_1 argument goes unused, it doesn't matter to check it anymore.
+// #[skyline::hook(replace = L2CFighterCommon_sub_check_passive_button)]
+// unsafe fn sub_check_passive_button(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
+//     // The basis of the new tech system, teching is now performed by having your stick tilted in
+//     // any direction that *isn't* down, so neutral causes missed techs.
+//     // This is also why that param_1 argument goes unused, it doesn't matter to check it anymore.
 
-    let stick_x = fighter.global_table[STICK_X].get_f32();
-    let stick_y = fighter.global_table[STICK_Y].get_f32();
-    let flick_x = fighter.global_table[FLICK_X].get_i32();
-    let flick_y = fighter.global_table[FLICK_Y].get_i32();
-    let passive_fb_cont_value = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("passive_fb_cont_value"));
-    let fb = passive_fb_cont_value <= stick_x.abs() && flick_x < 0xf0;
-    let jump_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("jump_stick_y"));
-    let jump = jump_stick_y <= stick_y.abs() && flick_y < 0xf0;
-    let guard_button = ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD);
-    let passive_input = ControlModule::get_trigger_count(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD as u8) < param_1.get_i32();
-    (fb || jump || guard_button || passive_input).into()
-}
+//     let stick_x = fighter.global_table[STICK_X].get_f32();
+//     let stick_y = fighter.global_table[STICK_Y].get_f32();
+//     let flick_x = fighter.global_table[FLICK_X].get_i32();
+//     let flick_y = fighter.global_table[FLICK_Y].get_i32();
+//     let passive_fb_cont_value = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("passive_fb_cont_value"));
+//     let fb = passive_fb_cont_value <= stick_x.abs() && flick_x < 0xf0;
+//     let jump_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("jump_stick_y"));
+//     let jump = jump_stick_y <= stick_y.abs() && flick_y < 0xf0;
+//     let guard_button = ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD);
+//     let passive_input = ControlModule::get_trigger_count(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD as u8) < param_1.get_i32();
+//     (fb || jump || guard_button || passive_input).into()
+// }
 
-#[skyline::hook(replace = L2CFighterCommon_sub_check_passive_button_for_damage)]
-unsafe fn sub_check_passive_button_for_damage(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
-    // Now just calls sub_check_passive_button
+// #[skyline::hook(replace = L2CFighterCommon_sub_check_passive_button_for_damage)]
+// unsafe fn sub_check_passive_button_for_damage(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
+//     // Now just calls sub_check_passive_button
 
-    fighter.sub_check_passive_button(param_1)
-}
+//     fighter.sub_check_passive_button(param_1)
+// }
 
 #[skyline::hook(replace = L2CFighterCommon_sub_AirChkPassive)]
 unsafe fn sub_airchkpassive(fighter: &mut L2CFighterCommon) -> L2CValue {
@@ -267,8 +267,8 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hooks!(
             is_enable_passive,
-            sub_check_passive_button,
-            sub_check_passive_button_for_damage,
+            // sub_check_passive_button,
+            // sub_check_passive_button_for_damage,
             sub_airchkpassive,
             sub_airchkpassive_for_damage,
             sub_airchkpassivewall,

--- a/src/fighter/common/common_status/passive.rs
+++ b/src/fighter/common/common_status/passive.rs
@@ -25,31 +25,21 @@ pub unsafe fn is_bad_passive(fighter: &mut L2CFighterCommon) -> L2CValue {
     (weight + passive::invalid_passive_damage_add <= damage).into()
 }
 
-// #[skyline::hook(replace = L2CFighterCommon_sub_check_passive_button)]
-// unsafe fn sub_check_passive_button(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
-//     // The basis of the new tech system, teching is now performed by having your stick tilted in
-//     // any direction that *isn't* down, so neutral causes missed techs.
-//     // This is also why that param_1 argument goes unused, it doesn't matter to check it anymore.
+#[skyline::hook(replace = L2CFighterCommon_sub_check_passive_button)]
+unsafe fn sub_check_passive_button(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
+    let passive_input = ControlModule::get_trigger_count(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD as u8) & 0xFF < param_1.get_i32();
+    passive_input.into()
+}
 
-//     let stick_x = fighter.global_table[STICK_X].get_f32();
-//     let stick_y = fighter.global_table[STICK_Y].get_f32();
-//     let flick_x = fighter.global_table[FLICK_X].get_i32();
-//     let flick_y = fighter.global_table[FLICK_Y].get_i32();
-//     let passive_fb_cont_value = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("passive_fb_cont_value"));
-//     let fb = passive_fb_cont_value <= stick_x.abs() && flick_x < 0xf0;
-//     let jump_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("jump_stick_y"));
-//     let jump = jump_stick_y <= stick_y.abs() && flick_y < 0xf0;
-//     let guard_button = ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD);
-//     let passive_input = ControlModule::get_trigger_count(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD as u8) < param_1.get_i32();
-//     (fb || jump || guard_button || passive_input).into()
-// }
-
-// #[skyline::hook(replace = L2CFighterCommon_sub_check_passive_button_for_damage)]
-// unsafe fn sub_check_passive_button_for_damage(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
-//     // Now just calls sub_check_passive_button
-
-//     fighter.sub_check_passive_button(param_1)
-// }
+#[skyline::hook(replace = L2CFighterCommon_sub_check_passive_button_for_damage)]
+unsafe fn sub_check_passive_button_for_damage(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
+    let reaction_frame = WorkModule::get_float(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLOAT_DAMAGE_REACTION_FRAME);
+    if reaction_frame <= 0.0
+    && ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD) {
+        return true.into();
+    }
+    fighter.sub_check_passive_button(param_1)
+}
 
 #[skyline::hook(replace = L2CFighterCommon_sub_AirChkPassive)]
 unsafe fn sub_airchkpassive(fighter: &mut L2CFighterCommon) -> L2CValue {
@@ -267,8 +257,8 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hooks!(
             is_enable_passive,
-            // sub_check_passive_button,
-            // sub_check_passive_button_for_damage,
+            sub_check_passive_button,
+            sub_check_passive_button_for_damage,
             sub_airchkpassive,
             sub_airchkpassive_for_damage,
             sub_airchkpassivewall,


### PR DESCRIPTION
In 0.15.0 I experimented with changing the tech input, modeling how it works based on how other games handle teching out of hitstun. However, while I *did* like it as a concept, this doesn't actually... work for Smash. So this reverts the tech input changes to vanilla (you need to press shield), and increases the window to tech from 12 to 20, like in the older Smash games.

In addition, this fixes an inconsistency when trying to tech from tumble, where sometimes you would airdodge and land and other times you would airdodge and tech. Now it *should* tech more consistently.