### PR TITLE
Olimar Changes

### DIFF
--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -630,6 +630,28 @@ pub mod pikachu_dengekidama {
     }
 }
 
+pub mod pikmin {
+    pub mod instance {
+        pub mod flag {
+            pub const ATTACK_HI3_LANDING : i32 = 0x0100;
+        }
+        pub mod int {
+            pub const ATTACK_S3_LOOP_COUNT : i32 = 0x0100;
+        }
+    }
+    pub mod status {
+        pub mod flag {
+            pub const ATTACK_HI3_DRIFT : i32 = 0x1150;
+        }
+        pub mod int {
+            pub const ATTACK_S3_STEP : i32 = 0x1150;
+        }
+    }
+    pub const ATTACK_S3_STEP_START : i32 = 0;
+    pub const ATTACK_S3_STEP_LOOP : i32 = 1;
+    pub const ATTACK_S3_STEP_END : i32 = 2;
+}
+
 pub mod ryu {
     pub mod instance {
         pub mod flag {

--- a/src/fighter/pikmin/acmd/normals.rs
+++ b/src/fighter/pikmin/acmd/normals.rs
@@ -2,13 +2,13 @@ use {
     smash::{
         lua2cpp::L2CAgentBase,
         phx::Hash40,
-        app::{lua_bind::*, sv_animcmd::*},
+        app::{lua_bind::*, sv_animcmd::*, *},
         lib::lua_const::*
     },
     custom_var::*,
     smash_script::*,
     smashline::*,
-    wubor_utils::vars::*
+    wubor_utils::{wua_bind::*, vars::*}
 };
 
 #[acmd_script( agent = "pikmin", script = "game_attacks3", category = ACMD_GAME, low_priority )]
@@ -134,7 +134,7 @@ unsafe fn pikmin_attackhi3(fighter: &mut L2CAgentBase) {
         if macros::is_excute(fighter) {
             macros::ATTACK(fighter, 0, 0, Hash40::new("trans"), 0.6, 120, 100, 50, 0, 3.5, 3.0, 4.0, 5.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
             macros::ATTACK(fighter, 1, 0, Hash40::new("trans"), 0.6, 120, 100, 50, 0, 3.5, -3.0, 4.0, 5.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
-            macros::ATTACK(fighter, 1, 0, Hash40::new("head"), 0.6, 92, 100, 20, 0, 5.0, 3.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
+            macros::ATTACK(fighter, 2, 0, Hash40::new("head"), 0.6, 92, 100, 20, 0, 5.0, 3.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
         }
         wait(fighter.lua_state_agent, 1.0);
         if macros::is_excute(fighter) {
@@ -152,11 +152,41 @@ unsafe fn pikmin_attackhi3(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "pikmin", script = "effect_attackhi3", category = ACMD_EFFECT, low_priority )]
+unsafe fn pikmin_attackhi3_eff(fighter: &mut L2CAgentBase) {
+    frame(fighter.lua_state_agent, 4.0);
+    if macros::is_excute(fighter) {
+        macros::LANDING_EFFECT(fighter, Hash40::new("sys_whirlwind_l"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0, 0, false);
+        macros::EFFECT_FOLLOW(fighter, Hash40::new("pikmin_attack_spin"), Hash40::new("trans"), 0, 11, 0.5, 0, 0, 0, 0.55, true);
+        macros::EFFECT_FOLLOW_ALPHA(fighter, Hash40::new("pikmin_attack_spin"), Hash40::new("trans"), 0, 6, 0.5, 0, 0, 0, 0.7, true, 0.7);
+    }
+    frame(fighter.lua_state_agent, 7.0);
+    if macros::is_excute(fighter) {
+        macros::EFFECT_FOLLOW_ALPHA(fighter, Hash40::new("pikmin_attack_spin"), Hash40::new("trans"), 0, 4, 0.5, 0, 0, 0, 0.85, true, 0.5);
+    }
+}
+
+#[acmd_script( agent = "pikmin", script = "sound_attackhi3", category = ACMD_SOUND, low_priority )]
+unsafe fn pikmin_attackhi3_snd(fighter: &mut L2CAgentBase) {
+    frame(fighter.lua_state_agent, 4.0);
+    if macros::is_excute(fighter) {
+        macros::PLAY_SE(fighter, Hash40::new("se_pikmin_attackhard_h01"));
+    }
+    wait(fighter.lua_state_agent, 4.0);
+    if macros::is_excute(fighter) {
+        macros::PLAY_SE(fighter, Hash40::new("se_pikmin_attackhard_h02"));
+    }
+    wait(fighter.lua_state_agent, 5.0);
+    if macros::is_excute(fighter) {
+        macros::PLAY_SE(fighter, Hash40::new("se_pikmin_attackhard_h03"));
+    }
+}
+
 pub fn install() {
     install_acmd_scripts!(
         pikmin_attacks3, pikmin_attacks3_snd,
         pikmin_attacks3loop_eff, pikmin_attacks3loop_snd, pikmin_attacks3loop_exp,
         pikmin_attacks3end, pikmin_attacks3end_eff, pikmin_attacks3end_snd, pikmin_attacks3end_exp,
-        pikmin_attackhi3
+        pikmin_attackhi3, pikmin_attackhi3_eff, pikmin_attackhi3_snd
     );
 }

--- a/src/fighter/pikmin/acmd/normals.rs
+++ b/src/fighter/pikmin/acmd/normals.rs
@@ -123,10 +123,40 @@ unsafe fn pikmin_attacks3end_exp(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "pikmin", script = "game_attackhi3", category = ACMD_GAME, low_priority )]
+unsafe fn pikmin_attackhi3(fighter: &mut L2CAgentBase) {
+    frame(fighter.lua_state_agent, 4.0);
+    if macros::is_excute(fighter) {
+        VarModule::on_flag(fighter.battle_object, pikmin::status::flag::ATTACK_HI3_DRIFT);
+    }
+    frame(fighter.lua_state_agent, 6.0);
+    for _ in 0..5 {
+        if macros::is_excute(fighter) {
+            macros::ATTACK(fighter, 0, 0, Hash40::new("trans"), 0.6, 120, 100, 50, 0, 3.5, 3.0, 4.0, 5.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
+            macros::ATTACK(fighter, 1, 0, Hash40::new("trans"), 0.6, 120, 100, 50, 0, 3.5, -3.0, 4.0, 5.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
+            macros::ATTACK(fighter, 1, 0, Hash40::new("head"), 0.6, 92, 100, 20, 0, 5.0, 3.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
+        }
+        wait(fighter.lua_state_agent, 1.0);
+        if macros::is_excute(fighter) {
+            AttackModule::clear_all(fighter.module_accessor);
+        }
+        wait(fighter.lua_state_agent, 1.0);
+    }
+    if macros::is_excute(fighter) {
+        macros::ATTACK(fighter, 0, 0, Hash40::new("trans"), 2.0, 90, 120, 0, 50, 7.0, 0.0, 11.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
+        macros::ATTACK(fighter, 1, 0, Hash40::new("trans"), 2.0, 90, 120, 0, 50, 6.0, 0.0, 17.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
+    }
+    wait(fighter.lua_state_agent, 1.0);
+    if macros::is_excute(fighter) {
+        AttackModule::clear_all(fighter.module_accessor);
+    }
+}
+
 pub fn install() {
     install_acmd_scripts!(
         pikmin_attacks3, pikmin_attacks3_snd,
         pikmin_attacks3loop_eff, pikmin_attacks3loop_snd, pikmin_attacks3loop_exp,
-        pikmin_attacks3end, pikmin_attacks3end_eff, pikmin_attacks3end_snd, pikmin_attacks3end_exp
+        pikmin_attacks3end, pikmin_attacks3end_eff, pikmin_attacks3end_snd, pikmin_attacks3end_exp,
+        pikmin_attackhi3
     );
 }

--- a/src/fighter/pikmin/acmd/normals.rs
+++ b/src/fighter/pikmin/acmd/normals.rs
@@ -5,29 +5,128 @@ use {
         app::{lua_bind::*, sv_animcmd::*},
         lib::lua_const::*
     },
+    custom_var::*,
     smash_script::*,
-    smashline::*
+    smashline::*,
+    wubor_utils::vars::*
 };
 
 #[acmd_script( agent = "pikmin", script = "game_attacks3", category = ACMD_GAME, low_priority )]
-unsafe fn pikmin_attacks3(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 15.0);
+unsafe fn pikmin_attacks3(_fighter: &mut L2CAgentBase) {
+    // Blank
+}
+
+#[acmd_script( agent = "pikmin", script = "sound_attacks3", category = ACMD_SOUND, low_priority )]
+unsafe fn pikmin_attacks3_snd(fighter: &mut L2CAgentBase) {
+    frame(fighter.lua_state_agent, 4.0);
     if macros::is_excute(fighter) {
-        macros::ATTACK(fighter, 0, 0, Hash40::new("top"), 11.0, 361, 97, 0, 40, 4.5, 0.0, 5.0, 13.5, Some(0.0), Some(5.0), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-        macros::ATTACK(fighter, 1, 0, Hash40::new("top"), 11.0, 361, 97, 0, 40, 2.8, 0.0, 5.0, 11.0, Some(0.0), Some(5.0), Some(5.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
+        macros::PLAY_SE(fighter, Hash40::new("se_pikmin_attackhard_s01"));
     }
-    frame(fighter.lua_state_agent, 16.0);
+}
+
+#[acmd_script( agent = "pikmin", script = "effect_attacks3loop", category = ACMD_EFFECT, low_priority )]
+unsafe fn pikmin_attacks3loop_eff(fighter: &mut L2CAgentBase) {
+    if macros::is_excute(fighter) {
+        macros::EFFECT_FOLLOW(fighter, Hash40::new("pikmin_punch_spin"), Hash40::new("top"), -3, 6, -2, -192, 4, 68, 0.85, true);
+    }
+}
+
+#[acmd_script( agent = "pikmin", script = "sound_attacks3loop", category = ACMD_SOUND, low_priority )]
+unsafe fn pikmin_attacks3loop_snd(fighter: &mut L2CAgentBase) {
+    if macros::is_excute(fighter) {
+        macros::PLAY_SE(fighter, Hash40::new("se_pikmin_attackhard_s01"));
+    }
+}
+
+#[acmd_script( agent = "pikmin", script = "expression_attacks3loop", category = ACMD_EXPRESSION, low_priority )]
+unsafe fn pikmin_attacks3loop_exp(fighter: &mut L2CAgentBase) {
+    if macros::is_excute(fighter) {
+        slope!(fighter, MA_MSC_CMD_SLOPE_SLOPE_INTP, SLOPE_STATUS_R);
+        ControlModule::set_rumble(
+            fighter.module_accessor,
+            Hash40::new("rbkind_nohits"),
+            7,
+            false,
+            *BATTLE_OBJECT_ID_INVALID as u32
+        );
+    }
+}
+
+#[acmd_script( agent = "pikmin", script = "game_attacks3end", category = ACMD_GAME, low_priority )]
+unsafe fn pikmin_attacks3end(fighter: &mut L2CAgentBase) {
+    frame(fighter.lua_state_agent, 4.0);
+    if macros::is_excute(fighter) {
+        let loops_real = VarModule::get_int(fighter.battle_object, pikmin::instance::int::ATTACK_S3_LOOP_COUNT);
+        let loops = loops_real.clamp(0, 6);
+        let damage_add = 1.5 * loops as f32;
+        let kbg_add = 5 * loops;
+        let shield_damage_add = 2 * loops;
+        let shieldstun_add = 0.1 * loops as f32;
+        macros::ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0 + damage_add, 361, 87 + kbg_add, 0, 35, 4.5, 0.0, 5.0, 13.5, Some(0.0), Some(5.0), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -2 + shield_damage_add, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
+        macros::ATTACK(fighter, 1, 0, Hash40::new("top"), 8.0 + damage_add, 361, 87 + kbg_add, 0, 35, 2.8, 0.0, 5.0, 11.0, Some(0.0), Some(5.0), Some(5.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -2 + shield_damage_add, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
+        macros::ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 0.8 + shieldstun_add);
+        macros::ATK_SET_SHIELD_SETOFF_MUL(fighter, 1, 0.8 + shieldstun_add);
+    }
+    frame(fighter.lua_state_agent, 5.0);
     if macros::is_excute(fighter) {
         AttackModule::clear(fighter.module_accessor, 0, false);
     }
-    frame(fighter.lua_state_agent, 18.0);
+    frame(fighter.lua_state_agent, 7.0);
     if macros::is_excute(fighter) {
         AttackModule::clear_all(fighter.module_accessor);
     }
 }
 
+#[acmd_script( agent = "pikmin", script = "effect_attacks3end", category = ACMD_EFFECT, low_priority )]
+unsafe fn pikmin_attacks3end_eff(fighter: &mut L2CAgentBase) {
+    frame(fighter.lua_state_agent, 1.0);
+    if macros::is_excute(fighter) {
+        macros::FOOT_EFFECT(fighter, Hash40::new("sys_run_smoke"), Hash40::new("top"), 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+    }
+    frame(fighter.lua_state_agent, 3.0);
+    if macros::is_excute(fighter) {
+        macros::EFFECT_FOLLOW_ALPHA(fighter, Hash40::new("sys_attack_line"), Hash40::new("top"), -2, 5.5, -5, 0, 0, 0, 1.1, false, 0.5);
+        macros::EFFECT_FOLLOW_ALPHA(fighter, Hash40::new("sys_attack_speedline"), Hash40::new("top"), -2, 5.5, -5, 0, 0, 0, 0.65, false, 0.6);
+    }
+    frame(fighter.lua_state_agent, 4.0);
+    if macros::is_excute(fighter) {
+        macros::EFFECT(fighter, Hash40::new("sys_attack_impact"), Hash40::new("top"), 0, 5.5, 13, 0, 0, 0, 1, 0, 0, 0, 0, 0, 360, true);
+    }
+}
+
+#[acmd_script( agent = "pikmin", script = "sound_attacks3end", category = ACMD_SOUND, low_priority )]
+unsafe fn pikmin_attacks3end_snd(fighter: &mut L2CAgentBase) {
+    if macros::is_excute(fighter) {
+        macros::PLAY_SE(fighter, Hash40::new("se_pikmin_attackhard_s02"));
+    }
+}
+
+#[acmd_script( agent = "pikmin", script = "expression_attacks3end", category = ACMD_EXPRESSION, low_priority )]
+unsafe fn pikmin_attacks3end_exp(fighter: &mut L2CAgentBase) {
+    if macros::is_excute(fighter) {
+        slope!(fighter, MA_MSC_CMD_SLOPE_SLOPE_INTP, SLOPE_STATUS_R, 5);
+    }
+    frame(fighter.lua_state_agent, 3.0);
+    if macros::is_excute(fighter) {
+        slope!(fighter, MA_MSC_CMD_SLOPE_SLOPE_INTP, SLOPE_STATUS_LR, 5);
+        ControlModule::set_rumble(
+            fighter.module_accessor,
+            Hash40::new("rbkind_nohits"),
+            0,
+            false,
+            *BATTLE_OBJECT_ID_INVALID as u32
+        );
+    }
+    frame(fighter.lua_state_agent, 4.0);
+    if macros::is_excute(fighter) {
+        macros::RUMBLE_HIT(fighter, Hash40::new("rbkind_attackm"), 0);
+    }
+}
+
 pub fn install() {
     install_acmd_scripts!(
-        pikmin_attacks3
+        pikmin_attacks3, pikmin_attacks3_snd,
+        pikmin_attacks3loop_eff, pikmin_attacks3loop_snd, pikmin_attacks3loop_exp,
+        pikmin_attacks3end, pikmin_attacks3end_eff, pikmin_attacks3end_snd, pikmin_attacks3end_exp
     );
 }

--- a/src/fighter/pikmin/acmd/normals.rs
+++ b/src/fighter/pikmin/acmd/normals.rs
@@ -11,6 +11,77 @@ use {
     wubor_utils::{wua_bind::*, vars::*}
 };
 
+#[acmd_script( agent = "pikmin", script = "game_attack11", category = ACMD_GAME, low_priority )]
+unsafe fn pikmin_attack11(fighter: &mut L2CAgentBase) {
+    frame(fighter.lua_state_agent, 4.0);
+    if macros::is_excute(fighter) {
+        macros::ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 361, 25, 0, 30, 2.4, 0.0, 5.0, 5.0, None, None, None, 1.6, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+        macros::ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 180, 25, 0, 30, 2.8, 0.0, 5.0, 8.0, None, None, None, 1.6, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+        macros::ATTACK(fighter, 2, 0, Hash40::new("top"), 3.0, 361, 25, 0, 30, 2.8, 0.0, 5.0, 8.0, None, None, None, 1.6, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+    }
+    wait(fighter.lua_state_agent, 1.0);
+    if macros::is_excute(fighter) {
+        macros::ATTACK(fighter, 1, 0, Hash40::new("top"), 4.0, 180, 15, 0, 25, 3.0, 0.0, 5.0, 10.8, None, None, None, 1.6, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+        macros::ATTACK(fighter, 2, 0, Hash40::new("top"), 4.0, 361, 15, 0, 25, 3.0, 0.0, 5.0, 10.8, None, None, None, 1.6, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+    }
+    wait(fighter.lua_state_agent, 1.0);
+    if macros::is_excute(fighter) {
+        AttackModule::clear_all(fighter.module_accessor);
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_COMBO);
+    }
+    macros::FT_MOTION_RATE(fighter, 4.0 / 9.0);
+    frame(fighter.lua_state_agent, 15.0);
+    macros::FT_MOTION_RATE(fighter, 1.0);
+    if macros::is_excute(fighter) {
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_NO_HIT_COMBO);
+    }
+}
+
+#[acmd_script( agent = "pikmin", script = "game_attackdash", category = ACMD_GAME, low_priority )]
+unsafe fn pikmin_attackdash(fighter: &mut L2CAgentBase) {
+    frame(fighter.lua_state_agent, 6.0);
+    for _ in 0..3 {
+        if macros::is_excute(fighter) {
+            AttackModule::clear_all(fighter.module_accessor);
+            macros::ATTACK(fighter, 0, 0, Hash40::new("trans"), 1.5, 365, 25, 50, 0, 4.0, 0.0, 7.0, 3.5, None, None, None, 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
+        }
+        wait(fighter.lua_state_agent, 2.0);
+    }
+    if macros::is_excute(fighter) {
+        AttackModule::clear_all(fighter.module_accessor);
+        macros::ATTACK(fighter, 0, 0, Hash40::new("trans"), 4.0, 75, 50, 0, 90, 4.5, 0.0, 7.0, 3.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
+    }
+    wait(fighter.lua_state_agent, 2.0);
+    if macros::is_excute(fighter) {
+        AttackModule::clear_all(fighter.module_accessor);
+    }
+}
+
+#[acmd_script( agent = "pikmin", script = "expression_attackdash", category = ACMD_EXPRESSION, low_priority )]
+unsafe fn pikmin_attackdash_exp(fighter: &mut L2CAgentBase) {
+    if macros::is_excute(fighter) {
+        slope!(fighter, MA_MSC_CMD_SLOPE_SLOPE_INTP, SLOPE_STATUS_TOP, 3, true);
+    }
+    frame(fighter.lua_state_agent, 4.0);
+    if macros::is_excute(fighter) {
+        ControlModule::set_rumble(
+            fighter.module_accessor,
+            Hash40::new("rbkind_nohitm"),
+            0,
+            false,
+            *BATTLE_OBJECT_ID_INVALID as u32
+        );
+    }
+    frame(fighter.lua_state_agent, 6.0);
+    if macros::is_excute(fighter) {
+        macros::RUMBLE_HIT(fighter, Hash40::new("rbkind_attacks"), 0);
+    }
+    frame(fighter.lua_state_agent, 14.0);
+    if macros::is_excute(fighter) {
+        slope!(fighter, MA_MSC_CMD_SLOPE_SLOPE_INTP, SLOPE_STATUS_LR, 4);
+    }
+}
+
 #[acmd_script( agent = "pikmin", script = "game_attacks3", category = ACMD_GAME, low_priority )]
 unsafe fn pikmin_attacks3(_fighter: &mut L2CAgentBase) {
     // Blank
@@ -182,11 +253,29 @@ unsafe fn pikmin_attackhi3_snd(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "pikmin", script = "game_attacklw3", category = ACMD_GAME, low_priority )]
+unsafe fn pikmin_attacklw3(fighter: &mut L2CAgentBase) {
+    frame(fighter.lua_state_agent, 6.0);
+    if macros::is_excute(fighter) {
+        macros::ATTACK(fighter, 0, 0, Hash40::new("head"), 6.0, 65, 115, 0, 30, 4.8, 4.0, 5.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_B, false, 0, 0.4, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_HEAD);
+        macros::ATTACK(fighter, 1, 0, Hash40::new("head"), 6.0, 65, 115, 0, 30, 4.0, 2.0, 2.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_B, false, 0, 0.4, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_HEAD);
+        AttackModule::set_attack_height_all(fighter.module_accessor, AttackHeight(*ATTACK_HEIGHT_LOW), false);
+    }
+    frame(fighter.lua_state_agent, 13.0);
+    if macros::is_excute(fighter) {
+        AttackModule::clear_all(fighter.module_accessor);
+    }
+    MiscModule::calc_motion_rate_from_cancel_frame(fighter, 13.0, -5.0);
+}
+
 pub fn install() {
     install_acmd_scripts!(
+        pikmin_attack11,
+        pikmin_attackdash, pikmin_attackdash_exp,
         pikmin_attacks3, pikmin_attacks3_snd,
         pikmin_attacks3loop_eff, pikmin_attacks3loop_snd, pikmin_attacks3loop_exp,
         pikmin_attacks3end, pikmin_attacks3end_eff, pikmin_attacks3end_snd, pikmin_attacks3end_exp,
-        pikmin_attackhi3, pikmin_attackhi3_eff, pikmin_attackhi3_snd
+        pikmin_attackhi3, pikmin_attackhi3_eff, pikmin_attackhi3_snd,
+        pikmin_attacklw3
     );
 }

--- a/src/fighter/pikmin/acmd/normals.rs
+++ b/src/fighter/pikmin/acmd/normals.rs
@@ -137,6 +137,7 @@ unsafe fn pikmin_attacks3end(fighter: &mut L2CAgentBase) {
         macros::ATTACK(fighter, 1, 0, Hash40::new("top"), 8.0 + damage_add, 361, 87 + kbg_add, 0, 35, 2.8, 0.0, 5.0, 11.0, Some(0.0), Some(5.0), Some(5.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -2 + shield_damage_add, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
         macros::ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 0.8 + shieldstun_add);
         macros::ATK_SET_SHIELD_SETOFF_MUL(fighter, 1, 0.8 + shieldstun_add);
+        VarModule::set_int(fighter.battle_object, pikmin::instance::int::ATTACK_S3_LOOP_COUNT, 0);
     }
     frame(fighter.lua_state_agent, 5.0);
     if macros::is_excute(fighter) {

--- a/src/fighter/pikmin/mod.rs
+++ b/src/fighter/pikmin/mod.rs
@@ -1,7 +1,9 @@
 mod acmd;
+mod status;
 mod frame;
 
 pub fn install() {
     acmd::install();
+    status::install();
     frame::install();
 }

--- a/src/fighter/pikmin/status.rs
+++ b/src/fighter/pikmin/status.rs
@@ -1,5 +1,9 @@
+mod landing;
 mod attack_s3;
+mod attack_hi3;
 
 pub fn install() {
+    landing::install();
     attack_s3::install();
+    attack_hi3::install();
 }

--- a/src/fighter/pikmin/status.rs
+++ b/src/fighter/pikmin/status.rs
@@ -1,0 +1,5 @@
+mod attack_s3;
+
+pub fn install() {
+    attack_s3::install();
+}

--- a/src/fighter/pikmin/status/attack_hi3.rs
+++ b/src/fighter/pikmin/status/attack_hi3.rs
@@ -1,0 +1,148 @@
+use {
+    smash::{
+        lua2cpp::L2CFighterCommon,
+        hash40,
+        phx::Hash40,
+        app::{lua_bind::*, *},
+        lib::{lua_const::*, L2CValue}
+    },
+    smash_script::*,
+    smashline::*,
+    custom_var::*,
+    custom_cancel::*,
+    wubor_utils::{vars::*, table_const::*}
+};
+
+#[status_script(agent = "pikmin", status = FIGHTER_STATUS_KIND_ATTACK_HI3, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
+unsafe fn pikmin_attackhi3_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_GROUND),
+        *FIGHTER_KINETIC_TYPE_MOTION_AIR,
+        *GROUND_CORRECT_KIND_AIR as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        (
+            *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_ATTACK_HI3 |
+            *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK
+        ) as u64,
+        0,
+        *FIGHTER_POWER_UP_ATTACK_BIT_ATTACK_3 as u32,
+        0
+    );
+    0.into()
+}
+
+#[status_script(agent = "pikmin", status = FIGHTER_STATUS_KIND_ATTACK_HI3, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe fn pikmin_attackhi3_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.status_AttackHi3_Common(Hash40::new("attack_hi3").into(), Hash40::new("attack_hi3").into());
+    WorkModule::enable_transition_term_group(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_GROUP_CHK_AIR_LANDING);
+    VarModule::on_flag(fighter.battle_object, pikmin::instance::flag::ATTACK_HI3_LANDING);
+    WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_LANDING_LIGHT);
+    let attack_frame = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_WORK_INT_FRAME);
+    let item_catch_frame_attack_3 = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("item_catch_frame_attack_3"));
+    if attack_frame <= item_catch_frame_attack_3 {
+        fighter.sub_GetLightItemImm(FIGHTER_STATUS_KIND_CATCH_WAIT.into());
+        if StatusModule::status_kind_que_from_script(fighter.module_accessor) as i32 != *STATUS_KIND_NONE {
+            return 0.into();
+        }
+    }
+    if !StopModule::is_stop(fighter.module_accessor) {
+        pikmin_attackhi3_substatus(fighter, false.into());
+    }
+    fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(pikmin_attackhi3_substatus as *const () as _));
+    fighter.sub_shift_status_main(L2CValue::Ptr(pikmin_attackhi3_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn pikmin_attackhi3_substatus(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
+    if param_1.get_bool() {
+        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_ATTACK_DISABLE_MINI_JUMP_ATTACK)
+        || WorkModule::count_down_int(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_ATTACK_MINI_JUMP_ATTACK_FRAME, 0) != 0 {
+            WorkModule::set_int(fighter.module_accessor, 0, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_ATTACK_MINI_JUMP_ATTACK_FRAME);
+            WorkModule::off_flag(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_ATTACK_DISABLE_MINI_JUMP_ATTACK);
+            WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_SQUAT_BUTTON);
+        }
+        WorkModule::inc_int(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_WORK_INT_FRAME);
+    }
+    0.into()
+}
+
+unsafe extern "C" fn pikmin_attackhi3_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if VarModule::is_flag(fighter.battle_object, pikmin::status::flag::ATTACK_HI3_DRIFT) {
+        VarModule::off_flag(fighter.battle_object, pikmin::status::flag::ATTACK_HI3_DRIFT);
+        sv_kinetic_energy!(
+            reset_energy,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_MOTION,
+            ENERGY_MOTION_RESET_TYPE_AIR_TRANS,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0
+        );
+        sv_kinetic_energy!(
+            clear_speed,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_CONTROL
+        );
+        sv_kinetic_energy!(
+            reset_energy,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+            ENERGY_CONTROLLER_RESET_TYPE_FALL_ADJUST,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0
+        );
+        KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+    }
+    if fighter.sub_transition_group_check_air_cliff().get_bool() {
+        return 1.into();
+    }
+    if CancelModule::is_enable_cancel(fighter.module_accessor) {
+        if fighter.sub_wait_ground_check_common(false.into()).get_bool()
+        || fighter.sub_air_check_fall_common().get_bool() {
+            return 0.into();
+        }
+    }
+    if CustomCancelManager::execute_cancel(fighter) {
+        return 1.into();
+    }
+    let trans = MotionModule::trans_move_speed(fighter.module_accessor);
+    if trans.y < -0.001 {
+        if fighter.sub_transition_group_check_air_landing().get_bool() {
+            WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_LANDING_LIGHT);
+            return 0.into();
+        }
+    }
+    if fighter.status_AttackHi3_Main_minjump().get_bool() {
+        VarModule::off_flag(fighter.battle_object, pikmin::instance::flag::ATTACK_HI3_LANDING);
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_LANDING_LIGHT);
+    }
+    if MotionModule::is_end(fighter.module_accessor) {
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_LANDING_LIGHT);
+    }
+    0.into()
+}
+
+pub fn install() {
+    install_status_scripts!(
+        pikmin_attackhi3_pre, pikmin_attackhi3_main
+    );
+}

--- a/src/fighter/pikmin/status/attack_s3.rs
+++ b/src/fighter/pikmin/status/attack_s3.rs
@@ -1,0 +1,131 @@
+use {
+    smash::{
+        lua2cpp::L2CFighterCommon,
+        hash40,
+        phx::Hash40,
+        app::lua_bind::*,
+        lib::{lua_const::*, L2CValue}
+    },
+    smashline::*,
+    custom_var::*,
+    custom_cancel::*,
+    wubor_utils::{vars::*, table_const::*}
+};
+
+#[status_script(agent = "pikmin", status = FIGHTER_STATUS_KIND_ATTACK_S3, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe fn pikmin_attacks3_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.status_AttackS3Common();
+    fighter.sub_shift_status_main(L2CValue::Ptr(pikmin_attacks3_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn pikmin_attacks3_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if CancelModule::is_enable_cancel(fighter.module_accessor)
+    && fighter.sub_wait_ground_check_common(false.into()).get_bool() {
+        return 0.into();
+    }
+    if CustomCancelManager::execute_cancel(fighter) {
+        return 1.into();
+    }
+    if !StatusModule::is_changing(fighter.module_accessor) {
+        let combo = ComboModule::count(fighter.module_accessor) as i32;
+        let s3_combo_max = WorkModule::get_param_int(fighter.module_accessor, hash40("s3_combo_max"), 0);
+        if combo < s3_combo_max
+        && WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_COMBO_PRECEDE)
+        && WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_COMBO) {
+            fighter.attack_s3_mtrans();
+        }
+    }
+    else {
+        fighter.attack_s3_mtrans();
+    }
+    if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_AIR {
+        let jump_attack_frame = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_ATTACK_MINI_JUMP_ATTACK_FRAME);
+        if 0 < jump_attack_frame {
+            if !StopModule::is_stop(fighter.module_accessor)
+            && fighter.sub_check_button_jump().get_bool() {
+                let log = fighter.status_attack();
+                let info = log[0x10f40d7b92u64].get_i64();
+                let mot = MotionModule::motion_kind(fighter.module_accessor);
+                MotionAnimcmdModule::call_script_single(
+                    fighter.module_accessor,
+                    *FIGHTER_ANIMCMD_EXPRESSION,
+                    Hash40::new_raw(mot),
+                    -1
+                );
+                WorkModule::set_int64(fighter.module_accessor, info, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
+                fighter.change_status_jump_mini_attack(true.into());
+                return 1.into();
+            }
+        }
+        if 1 == jump_attack_frame {
+            if fighter.global_table[IS_STOP].get_bool()
+            && WorkModule::get_int64(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND) > 0 {
+                let log = WorkModule::get_int64(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
+                FighterStatusModuleImpl::reset_log_action_info(fighter.module_accessor, log);
+                WorkModule::set_int64(fighter.module_accessor, 0, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
+            }
+        }
+        if MotionModule::is_end(fighter.module_accessor) {
+            if pikmin_attacks3_handle_loop(fighter).get_bool() {
+                return 0.into();
+            }
+        }
+    }
+    else {
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+    }
+    0.into()
+}
+
+unsafe extern "C" fn pikmin_attacks3_handle_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let step = VarModule::get_int(fighter.battle_object, pikmin::status::int::ATTACK_S3_STEP);
+    if step != pikmin::ATTACK_S3_STEP_END {
+        if fighter.sub_transition_group_check_ground_guard().get_bool() {
+            return true.into();
+        }
+        let mot;
+        let step;
+        if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_ATTACK) {
+            mot = hash40("attack_s3_loop");
+            step = pikmin::ATTACK_S3_STEP_LOOP;
+            WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_GUARD_ON);
+            VarModule::inc_int(fighter.battle_object, pikmin::instance::int::ATTACK_S3_LOOP_COUNT);
+        }
+        else {
+            mot = hash40("attack_s3_end");
+            step = pikmin::ATTACK_S3_STEP_END;
+            WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_GUARD_ON);
+        }
+        MotionModule::change_motion(
+            fighter.module_accessor,
+            Hash40::new_raw(mot),
+            0.0,
+            1.0,
+            false,
+            0.0,
+            false,
+            false
+        );
+        VarModule::set_int(fighter.battle_object, pikmin::status::int::ATTACK_S3_STEP, step);
+        false.into()
+    }
+    else {
+        fighter.change_status(FIGHTER_STATUS_KIND_WAIT.into(), false.into());
+        true.into()
+    }
+}
+
+#[status_script(agent = "pikmin", status = FIGHTER_STATUS_KIND_ATTACK_S3, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
+unsafe fn pikmin_attacks3_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.global_table[STATUS_KIND].get_i32() != *FIGHTER_STATUS_KIND_GUARD_ON {
+        VarModule::set_int(fighter.battle_object, pikmin::instance::int::ATTACK_S3_LOOP_COUNT, 0);
+    }
+    fighter.status_end_AttackS3()
+}
+
+pub fn install() {
+    install_status_scripts!(
+        pikmin_attacks3_main,
+        pikmin_attacks3_end
+    );
+}

--- a/src/fighter/pikmin/status/landing.rs
+++ b/src/fighter/pikmin/status/landing.rs
@@ -1,0 +1,76 @@
+use {
+    smash::{
+        lua2cpp::L2CFighterCommon,
+        app::lua_bind::*,
+        lib::{lua_const::*, L2CValue}
+    },
+    smashline::*,
+    custom_var::*,
+    wubor_utils::{vars::*, table_const::*}
+};
+
+#[status_script(agent = "pikmin", status = FIGHTER_STATUS_KIND_LANDING_LIGHT, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
+unsafe fn pikmin_landinglight_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    pikmin_landing_init_inner(fighter)
+}
+
+#[status_script(agent = "pikmin", status = FIGHTER_STATUS_KIND_LANDING_LIGHT, condition = LUA_SCRIPT_STATUS_FUNC_EXIT_STATUS)]
+unsafe fn pikmin_landinglight_exit(fighter: &mut L2CFighterCommon) -> L2CValue {
+    pikmin_landing_exit_inner(fighter)
+}
+
+#[status_script(agent = "pikmin", status = FIGHTER_STATUS_KIND_LANDING, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
+unsafe fn pikmin_landing_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    pikmin_landing_init_inner(fighter)
+}
+
+#[status_script(agent = "pikmin", status = FIGHTER_STATUS_KIND_LANDING, condition = LUA_SCRIPT_STATUS_FUNC_EXEC_STATUS)]
+unsafe fn pikmin_landing_exec(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.sub_landing_uniq_process_exec();
+    if fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() == *FIGHTER_STATUS_KIND_LANDING {
+        if VarModule::is_flag(fighter.battle_object, pikmin::instance::flag::ATTACK_HI3_LANDING) {
+            if MotionModule::frame(fighter.module_accessor) < 20.0 {
+                WorkModule::off_flag(fighter.module_accessor, *FIGHTER_STATUS_LANDING_FLAG_STIFF_CANCEL);
+            }
+        }
+    }
+    0.into()
+}
+
+#[status_script(agent = "pikmin", status = FIGHTER_STATUS_KIND_LANDING, condition = LUA_SCRIPT_STATUS_FUNC_EXIT_STATUS)]
+unsafe fn pikmin_landing_exit(fighter: &mut L2CFighterCommon) -> L2CValue {
+    pikmin_landing_exit_inner(fighter)
+}
+
+#[status_script(agent = "pikmin", status = FIGHTER_STATUS_KIND_LANDING_ATTACK_AIR, condition = LUA_SCRIPT_STATUS_FUNC_EXIT_STATUS)]
+unsafe fn pikmin_landingattackair_exit(fighter: &mut L2CFighterCommon) -> L2CValue {
+    pikmin_landing_exit_inner(fighter)
+}
+
+#[status_script(agent = "pikmin", status = FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL, condition = LUA_SCRIPT_STATUS_FUNC_EXIT_STATUS)]
+unsafe fn pikmin_landingfallspecial_exit(fighter: &mut L2CFighterCommon) -> L2CValue {
+    pikmin_landing_exit_inner(fighter)
+}
+
+unsafe fn pikmin_landing_init_inner(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if VarModule::is_flag(fighter.battle_object, pikmin::instance::flag::ATTACK_HI3_LANDING) {
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_TURN);
+    }
+    fighter.sub_landing_uniq_process_init();
+    0.into()
+}
+
+unsafe fn pikmin_landing_exit_inner(fighter: &mut L2CFighterCommon) -> L2CValue {
+    VarModule::off_flag(fighter.battle_object, pikmin::instance::flag::ATTACK_HI3_LANDING);
+    fighter.sub_landing_uniq_process_exit();
+    0.into()
+}
+
+pub fn install() {
+    install_status_scripts!(
+        pikmin_landinglight_init, pikmin_landinglight_exit,
+        pikmin_landing_init, pikmin_landing_exec, pikmin_landing_exit,
+        pikmin_landingattackair_exit, pikmin_landingattackair_exit,
+        pikmin_landingfallspecial_exit
+    );
+}


### PR DESCRIPTION
Mostly for the sake of fun, here are some Olimar changes.

Changelog:
Jab 1
- [x] Has 5 frames less endlag (20 > 15).

Dash Attack
- [x] Has 3 multi-hits that deal 1.5%, then the 4% launching hitbox from the original move.

F.Tilt
- [x] Can now be charged by holding Attack. Olimar can charge up to 7 arm swings to increase the move's power.
- [x] Olimar can cancel the wind-up with Shield.
- [x] Olimar can keep his charge progress if he cancels into shield specifically.

U.Tilt
- [x] Is now treated as an airborne move, like Mega Man's U.Tilt.
- [x] Olimar can drift left or right while performing the move.
- [x] Olimar becomes actionable before he touches the ground.
- [x] If he touches the ground after using U.Tilt, he takes 20 frames of landing lag.

D.Tilt
- [x] Now sends the opponents behind Olimar at a 65 degree angle.
- [x] Has 5 frames less endlag (30 > 25).