### PR TITLE
Balloon KB is now based on KB Speed

### DIFF
--- a/src/fighter/common/common_param.rs
+++ b/src/fighter/common/common_param.rs
@@ -18,6 +18,11 @@ pub mod jump {
     pub const super_jump_gravity : f32 = 0.27;
 }
 
+pub mod damage {
+    pub const damage_speed_up_speed_min : f32 = 3.0;
+    pub const damage_speed_up_speed_max : f32 = 6.0;
+}
+
 // Command Input Params
 
 // pub const command_input_window : i32 = 11;

--- a/src/fighter/common/common_status/damage.rs
+++ b/src/fighter/common/common_status/damage.rs
@@ -7,7 +7,8 @@ use {
         lib::{lua_const::*, L2CValue}
     },
     smash_script::*,
-    wubor_utils::table_const::*
+    wubor_utils::table_const::*,
+    super::super::common_param
 };
 
 #[skyline::hook(replace = L2CFighterCommon_status_pre_Damage)]
@@ -123,8 +124,8 @@ unsafe fn fighterstatusdamage_init_damage_speed_up_by_speed(
     angle: L2CValue,
     some_bool: L2CValue
 ) {
-    let factor_min = 3.0;
-    let factor_max = 6.0;
+    let factor_min = common_param::damage::damage_speed_up_speed_min;
+    let factor_max = common_param::damage::damage_speed_up_speed_max;
     let speed_up_mag = WorkModule::get_param_int(fighter.module_accessor, hash40("battle_object"), hash40("damage_fly_speed_up_max_mag")) as f32;
     if !check_damage_speed_up_by_speed(fighter.module_accessor, factor.get_f32())
     && !some_bool.get_bool() {
@@ -159,7 +160,7 @@ unsafe fn check_damage_speed_up_by_speed(module_accessor: *mut BattleObjectModul
     let log = DamageModule::damage_log(module_accessor);
     if log != 0 {
         let log = log as *mut u8;
-        if speed <= 3.5 || *log.add(0x8f) != 0 || *log.add(0x92) != 0
+        if speed <= common_param::damage::damage_speed_up_speed_min || *log.add(0x8f) != 0 || *log.add(0x92) != 0
         || *log.add(0x93) != 0 || *log.add(0x98) != 0 {
             false
         }

--- a/src/fighter/common/common_status/damage.rs
+++ b/src/fighter/common/common_status/damage.rs
@@ -57,7 +57,7 @@ unsafe fn ftstatusuniqprocessdamage_init_common(fighter: &mut L2CFighterCommon) 
     lua_args!(fighter, hash40("attr"));
     sv_information::damage_log_value(fighter.lua_state_agent);
     let attr = fighter.pop_lua_stack(1).get_u64();
-    // println!("damage log value attr: {}", attr);
+    // println!("damage log value attr: {:#x}", attr);
     let _status = StatusModule::status_kind(fighter.module_accessor);
     // this isn't used in anyhthing???
     if 0 >= reaction_frame as i32 {
@@ -84,11 +84,10 @@ unsafe fn ftstatusuniqprocessdamage_init_common(fighter: &mut L2CFighterCommon) 
     // println!("damage log value angle: {}", angle);
     let degrees = angle.to_degrees();
     // println!("degrees: {}", degrees);
-    // let speed_vector = sv_math::vec2_length(damage_speed_x, damage_speed_y);
+    let speed_vector = sv_math::vec2_length(speed_vec_x, speed_vec_y);
     // println!("speed vector: {}", speed_vector);
-    // if speed_vector >= 3.5 {
-        fighter.FighterStatusDamage_init_damage_speed_up(reaction_frame.into(), degrees.into(), false.into());
-    // }
+    // fighter.FighterStatusDamage_init_damage_speed_up(speed_vector.into(), degrees.into(), false.into());
+    fighterstatusdamage_init_damage_speed_up_by_speed(fighter, speed_vector.into(), degrees.into(), false.into());
     let damage_cliff_no_catch_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("damage_cliff_no_catch_frame"));
     WorkModule::set_int(fighter.module_accessor, damage_cliff_no_catch_frame, *FIGHTER_INSTANCE_WORK_ID_INT_CLIFF_NO_CATCH_FRAME);
     let cursor_fly_speed = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("cursor_fly_speed"));
@@ -116,6 +115,69 @@ unsafe fn ftstatusuniqprocessdamage_init_common(fighter: &mut L2CFighterCommon) 
         let invalid_paralyze_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("invalid_paralyze_frame"));
         WorkModule::set_float(fighter.module_accessor, invalid_paralyze_frame, *FIGHTER_INSTANCE_WORK_ID_INT_INVALID_PARALYZE_FRAME);
     }
+}
+
+unsafe fn fighterstatusdamage_init_damage_speed_up_by_speed(
+    fighter: &mut L2CFighterCommon,
+    factor: L2CValue, // Labeled this way because if shot out of a tornado, the game will pass in your hitstun frames instead of speed.
+    angle: L2CValue,
+    some_bool: L2CValue
+) {
+    let factor_min = 3.0;
+    let factor_max = 6.0;
+    let speed_up_mag = WorkModule::get_param_int(fighter.module_accessor, hash40("battle_object"), hash40("damage_fly_speed_up_max_mag")) as f32;
+    if !check_damage_speed_up_by_speed(fighter.module_accessor, factor.get_f32())
+    && !some_bool.get_bool() {
+        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DAMAGE_SPEED_UP);
+        WorkModule::set_float(fighter.module_accessor, 0.0, *FIGHTER_INSTANCE_WORK_ID_FLOAT_DAMAGE_SPEED_UP_MAX_MAG);
+        return;
+    }
+    // println!("speeding up!");
+    let speed_diff = factor.get_f32() - factor_min;
+    let speed_max = factor_max - factor_min;
+    let ratio = (speed_diff / speed_max).clamp(0.0, 1.0);
+    let mut mag = fighter.lerp((1.0).into(), speed_up_mag.into(), ratio.into()).get_f32();
+    // The logic below is actually vanilla, but this is trying to lineraly interpolate 1.0... to 1.0, so it doesn't *do* anything.
+    let angle_base = WorkModule::get_param_float(fighter.module_accessor, hash40("battle_object"), hash40("damage_fly_speed_up_angle_base"));
+    let angle_min_max = WorkModule::get_param_float(fighter.module_accessor, hash40("battle_object"), hash40("damage_fly_speed_up_min_max_angle"));
+    let angle_min = angle_base - angle_min_max;
+    let angle_max = angle_base + angle_min_max;
+    if angle_min < angle.get_f32() && angle.get_f32() <= angle_base {
+        // println!("Angle Min {} < Angle {} <= Angle Base {}", angle_min, angle.get_f32(), angle_base);
+        mag *= init_damage_speed_up_inner(fighter, angle.get_f32(), angle_min, angle_base);
+    }
+    else if angle_base < angle.get_f32() && angle.get_f32() <= angle_min {
+        // println!("Angle Min {} < Angle {} <= Angle Base {}", angle_base, angle.get_f32(), angle_max);
+        mag *= init_damage_speed_up_inner(fighter, angle.get_f32(), angle_base, angle_max);
+    }
+    // println!("Speed Up Magnitude: {}", mag);
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DAMAGE_SPEED_UP);
+    WorkModule::set_float(fighter.module_accessor, mag, *FIGHTER_INSTANCE_WORK_ID_FLOAT_DAMAGE_SPEED_UP_MAX_MAG);
+}
+
+unsafe fn check_damage_speed_up_by_speed(module_accessor: *mut BattleObjectModuleAccessor, speed: f32) -> bool {
+    let log = DamageModule::damage_log(module_accessor);
+    if log != 0 {
+        let log = log as *mut u8;
+        if speed <= 3.5 || *log.add(0x8f) != 0 || *log.add(0x92) != 0
+        || *log.add(0x93) != 0 || *log.add(0x98) != 0 {
+            false
+        }
+        else {
+            true
+        }
+    }
+    else {
+        false
+    }
+}
+
+unsafe fn init_damage_speed_up_inner(fighter: &mut L2CFighterCommon, angle: f32, lower: f32, upper: f32) -> f32 {
+    let diff = angle - lower;
+    let range = upper - lower;
+    let ratio = (diff / range).clamp(0.0, 1.0);
+    let angle_rate = WorkModule::get_param_float(fighter.module_accessor, hash40("battle_object"), hash40("damage_fly_speed_up_angle_rate"));
+    fighter.lerp((1.0).into(), (angle_rate * 0.01).into(), ratio.into()).get_f32()
 }
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_FighterStatusUniqProcessDamage_leave_stop)]

--- a/src/fighter/lucina/acmd/specials.rs
+++ b/src/fighter/lucina/acmd/specials.rs
@@ -314,7 +314,7 @@ unsafe fn lucina_specialhi(fighter: &mut L2CAgentBase) {
         frame(fighter.lua_state_agent, 10.0);
         macros::FT_MOTION_RATE(fighter, 1.0);
         if macros::is_excute(fighter) {
-            macros::ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 79, 100, 160, 0, 5.1, 0.0, 11.0, 10.0, Some(0.0), Some(7.0), Some(10.0), 1.5, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_SWORD);
+            macros::ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 79, 100, 100, 0, 5.1, 0.0, 11.0, 10.0, Some(0.0), Some(7.0), Some(10.0), 1.5, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_SWORD);
             AttackModule::set_no_damage_fly_smoke_all(fighter.module_accessor, true, false);
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_MARTH_STATUS_SPECIAL_HI_FLAG_SPECIAL_HI_SET_LR);
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_MARTH_STATUS_SPECIAL_HI_FLAG_TRANS_MOVE);
@@ -341,7 +341,7 @@ unsafe fn lucina_specialhi(fighter: &mut L2CAgentBase) {
         frame(fighter.lua_state_agent, 10.0);
         if macros::is_excute(fighter) {
             upper_invuln(fighter.module_accessor, false);
-            macros::ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 79, 100, 160, 0, 5.1, 0.0, 11.0, 10.0, Some(0.0), Some(7.0), Some(10.0), 1.8, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+            macros::ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 79, 100, 100, 0, 5.1, 0.0, 11.0, 10.0, Some(0.0), Some(7.0), Some(10.0), 1.8, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
             AttackModule::set_no_damage_fly_smoke_all(fighter.module_accessor, true, false);
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_MARTH_STATUS_SPECIAL_HI_FLAG_SPECIAL_HI_SET_LR);
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_MARTH_STATUS_SPECIAL_HI_FLAG_TRANS_MOVE);
@@ -475,7 +475,7 @@ unsafe fn lucina_specialairhi(fighter: &mut L2CAgentBase) {
         frame(fighter.lua_state_agent, 10.0);
         macros::FT_MOTION_RATE(fighter, 1.0);
         if macros::is_excute(fighter) {
-            macros::ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 79, 100, 160, 0, 5.1, 0.0, 11.0, 10.0, Some(0.0), Some(7.0), Some(10.0), 1.5, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_SWORD);
+            macros::ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 79, 100, 100, 0, 5.1, 0.0, 11.0, 10.0, Some(0.0), Some(7.0), Some(10.0), 1.5, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_SWORD);
             AttackModule::set_no_damage_fly_smoke_all(fighter.module_accessor, true, false);
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_MARTH_STATUS_SPECIAL_HI_FLAG_SPECIAL_HI_SET_LR);
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_MARTH_STATUS_SPECIAL_HI_FLAG_TRANS_MOVE);
@@ -502,7 +502,7 @@ unsafe fn lucina_specialairhi(fighter: &mut L2CAgentBase) {
         frame(fighter.lua_state_agent, 10.0);
         if macros::is_excute(fighter) {
             upper_invuln(fighter.module_accessor, false);
-            macros::ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 79, 100, 160, 0, 5.1, 0.0, 11.0, 10.0, Some(0.0), Some(7.0), Some(10.0), 1.8, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+            macros::ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 79, 100, 100, 0, 5.1, 0.0, 11.0, 10.0, Some(0.0), Some(7.0), Some(10.0), 1.8, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
             AttackModule::set_no_damage_fly_smoke_all(fighter.module_accessor, true, false);
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_MARTH_STATUS_SPECIAL_HI_FLAG_SPECIAL_HI_SET_LR);
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_MARTH_STATUS_SPECIAL_HI_FLAG_TRANS_MOVE);


### PR DESCRIPTION
Before, Balloon Knockback (known as Damage Speed-Up internally) used Hitstun Frames (reaction_frame) to determine if knockback is adjusted. Now, it's based on your knockback speed.

Changelog:
- [x] Balloon Knockback now scales based on knockback speed, instead of hitstun frames.
  - [x] Balloon Knockback kicks in at 3.0 knockback speed.
  - [x] Balloon Knockback caps its scaling at 6.0 knockback speed.

Subject to change.