### PR TITLE
Removes "Bad Techs" when teching while Corkscrewing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wubor"
-version = "0.15.2"
+version = "0.15.3"
 authors = ["WuBoy and Bor"]
 edition = "2018"
 

--- a/src/fighter/common/param.rs
+++ b/src/fighter/common/param.rs
@@ -7,7 +7,6 @@ pub const guard_off_invalid_capture_frame_add : i32 = 3;
 
 pub mod passive {
     pub const invalid_passive_damage_add : f32 = 33.0;
-    pub const bad_passive_rate : f32 = 0.75;
 }
 
 pub mod jump {


### PR DESCRIPTION
0.15.1 introduced "Bad Techs" where you would have a slower tech animation and no intangibility if you teched while above weight + 33 %. This removes that, making all hits normally techable, save for intentionally untechable moves.