### PR TITLE
Overhauled Air Dash - 0.15.3

### DIFF
--- a/src/fighter/bayonetta/acmd/escape.rs
+++ b/src/fighter/bayonetta/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "bayonetta", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn bayonetta_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/brave/acmd/escape.rs
+++ b/src/fighter/brave/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "brave", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn brave_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/buddy/acmd/escape.rs
+++ b/src/fighter/buddy/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "buddy", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn buddy_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/captain/acmd/escape.rs
+++ b/src/fighter/captain/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "captain", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn captain_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/chrom/acmd/escape.rs
+++ b/src/fighter/chrom/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "chrom", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn chrom_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/cloud/acmd/escape.rs
+++ b/src/fighter/cloud/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "cloud", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn cloud_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/daisy/acmd/escape.rs
+++ b/src/fighter/daisy/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "daisy", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn daisy_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/dedede/acmd/escape.rs
+++ b/src/fighter/dedede/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "dedede", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn dedede_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/demon/acmd/escape.rs
+++ b/src/fighter/demon/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "demon", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn demon_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/diddy/acmd/escape.rs
+++ b/src/fighter/diddy/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "diddy", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn diddy_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/dolly/acmd/escape.rs
+++ b/src/fighter/dolly/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "dolly", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn dolly_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/donkey/acmd/escape.rs
+++ b/src/fighter/donkey/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "donkey", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn donkey_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/duckhunt/acmd/escape.rs
+++ b/src/fighter/duckhunt/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "duckhunt", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn duckhunt_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/edge/acmd/escape.rs
+++ b/src/fighter/edge/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "edge", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn edge_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/eflame/acmd/escape.rs
+++ b/src/fighter/eflame/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "eflame", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn eflame_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/elight/acmd/escape.rs
+++ b/src/fighter/elight/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "elight", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn elight_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }
@@ -15,7 +15,7 @@ unsafe fn elight_escapeairslide(fighter: &mut L2CAgentBase) {
 
 #[acmd_script( agent = "elight", script = "game_escapeairslideforesight", category = ACMD_GAME, low_priority )]
 unsafe fn elight_escapeairslideforesight(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/falco/acmd/escape.rs
+++ b/src/fighter/falco/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "falco", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn falco_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/fox/acmd/escape.rs
+++ b/src/fighter/fox/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "fox", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn fox_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/gamewatch/acmd/escape.rs
+++ b/src/fighter/gamewatch/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "gamewatch", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn gamewatch_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/ganon/acmd/escape.rs
+++ b/src/fighter/ganon/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "ganon", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn ganon_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/gaogaen/acmd/escape.rs
+++ b/src/fighter/gaogaen/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "gaogaen", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn gaogaen_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/gekkouga/acmd/escape.rs
+++ b/src/fighter/gekkouga/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "gekkouga", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn gekkouga_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/iceclimber/acmd/escape.rs
+++ b/src/fighter/iceclimber/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "popo", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn popo_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }
@@ -15,7 +15,7 @@ unsafe fn popo_escapeairslide(fighter: &mut L2CAgentBase) {
 
 #[acmd_script( agent = "popo", script = "game_escapeairslide_nana", category = ACMD_GAME, low_priority )]
 unsafe fn popo_escapeairslide_nana(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }
@@ -28,7 +28,7 @@ unsafe fn popo_escapeairslide_nana(fighter: &mut L2CAgentBase) {
 
 #[acmd_script( agent = "nana", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn nana_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }
@@ -41,7 +41,7 @@ unsafe fn nana_escapeairslide(fighter: &mut L2CAgentBase) {
 
 #[acmd_script( agent = "nana", script = "game_escapeairslide_nana", category = ACMD_GAME, low_priority )]
 unsafe fn nana_escapeairslide_nana(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/ike/acmd/escape.rs
+++ b/src/fighter/ike/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "ike", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn ike_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/inkling/acmd/escape.rs
+++ b/src/fighter/inkling/acmd/escape.rs
@@ -12,7 +12,7 @@ unsafe fn inkling_escapeairslide(fighter: &mut L2CAgentBase) {
     if macros::is_excute(fighter) {
         VisibilityModule::set_whole(fighter.module_accessor, false);
     }
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/jack/acmd/escape.rs
+++ b/src/fighter/jack/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "jack", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn jack_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/kamui/acmd/escape.rs
+++ b/src/fighter/kamui/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "kamui", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn kamui_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/ken/acmd/escape.rs
+++ b/src/fighter/ken/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "ken", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn ken_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/kirby/acmd/escape.rs
+++ b/src/fighter/kirby/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "kirby", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn kirby_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/koopa/acmd/escape.rs
+++ b/src/fighter/koopa/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "koopa", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn koopa_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/koopajr/acmd/escape.rs
+++ b/src/fighter/koopajr/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "koopajr", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn koopajr_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/krool/acmd/escape.rs
+++ b/src/fighter/krool/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "krool", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn krool_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/link/acmd/escape.rs
+++ b/src/fighter/link/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "link", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn link_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/littlemac/acmd/escape.rs
+++ b/src/fighter/littlemac/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "littlemac", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn littlemac_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/lucario/acmd/escape.rs
+++ b/src/fighter/lucario/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "lucario", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn lucario_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/lucas/acmd/escape.rs
+++ b/src/fighter/lucas/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "lucas", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn lucas_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/lucina/acmd/escape.rs
+++ b/src/fighter/lucina/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "lucina", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn lucina_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/luigi/acmd/escape.rs
+++ b/src/fighter/luigi/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "luigi", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn luigi_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/mario/acmd/escape.rs
+++ b/src/fighter/mario/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "mario", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn mario_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/mariod/acmd/escape.rs
+++ b/src/fighter/mariod/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "mariod", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn mariod_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/marth/acmd/escape.rs
+++ b/src/fighter/marth/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "marth", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn marth_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/master/acmd/escape.rs
+++ b/src/fighter/master/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "master", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn master_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/metaknight/acmd/escape.rs
+++ b/src/fighter/metaknight/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "meaknight", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn meaknight_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/miifighter/acmd/escape.rs
+++ b/src/fighter/miifighter/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "miifighter", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn miifighter_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/miigunner/acmd/escape.rs
+++ b/src/fighter/miigunner/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "miigunner", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn miigunner_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/miiswordsman/acmd/escape.rs
+++ b/src/fighter/miiswordsman/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "miiswordsman", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn miiswordsman_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/murabito/acmd/escape.rs
+++ b/src/fighter/murabito/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "murabito", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn murabito_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/ness/acmd/escape.rs
+++ b/src/fighter/ness/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "ness", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn ness_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/packun/acmd/escape.rs
+++ b/src/fighter/packun/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "packun", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn packun_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/pacman/acmd/escape.rs
+++ b/src/fighter/pacman/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "pacman", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn pacman_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/palutena/acmd/escape.rs
+++ b/src/fighter/palutena/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "palutena", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn palutena_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/peach/acmd/escape.rs
+++ b/src/fighter/peach/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "peach", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn peach_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/pfushigisou/acmd/escape.rs
+++ b/src/fighter/pfushigisou/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "pfushigisou", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn pfushigisou_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/pichu/acmd/escape.rs
+++ b/src/fighter/pichu/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "pichu", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn pichu_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/pickel/acmd/escape.rs
+++ b/src/fighter/pickel/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "pickel", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn pickel_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/pikachu/acmd/escape.rs
+++ b/src/fighter/pikachu/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "pikachu", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn pikachu_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/pikmin/acmd/escape.rs
+++ b/src/fighter/pikmin/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "pikmin", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn pikmin_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/pit/acmd/escape.rs
+++ b/src/fighter/pit/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "pit", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn pit_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/pitb/acmd/escape.rs
+++ b/src/fighter/pitb/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "pitb", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn pitb_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/plizardon/acmd/escape.rs
+++ b/src/fighter/plizardon/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "plizardon", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn plizardon_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/purin/acmd/escape.rs
+++ b/src/fighter/purin/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "purin", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn purin_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/pzenigame/acmd/escape.rs
+++ b/src/fighter/pzenigame/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "pzenigame", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn pzenigame_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/reflet/acmd/escape.rs
+++ b/src/fighter/reflet/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "reflet", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn reflet_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/richter/acmd/escape.rs
+++ b/src/fighter/richter/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "richter", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn richter_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/ridley/acmd/escape.rs
+++ b/src/fighter/ridley/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "ridley", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn ridley_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/robot/acmd/escape.rs
+++ b/src/fighter/robot/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "robot", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn robot_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/rockman/acmd/escape.rs
+++ b/src/fighter/rockman/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "rockman", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn rockman_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/rosetta/acmd/escape.rs
+++ b/src/fighter/rosetta/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "rosetta", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn rosetta_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/roy/acmd/escape.rs
+++ b/src/fighter/roy/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "roy", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn roy_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/ryu/acmd/escape.rs
+++ b/src/fighter/ryu/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "ryu", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn ryu_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/samus/acmd/escape.rs
+++ b/src/fighter/samus/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "samus", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn samus_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/samusd/acmd/escape.rs
+++ b/src/fighter/samusd/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "samusd", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn samusd_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/sheik/acmd/escape.rs
+++ b/src/fighter/sheik/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "sheik", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn sheik_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/shizue/acmd/escape.rs
+++ b/src/fighter/shizue/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "shizue", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn shizue_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/shulk/acmd/escape.rs
+++ b/src/fighter/shulk/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "shulk", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn shulk_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/simon/acmd/escape.rs
+++ b/src/fighter/simon/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "simon", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn simon_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/snake/acmd/escape.rs
+++ b/src/fighter/snake/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "snake", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn snake_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/sonic/acmd/escape.rs
+++ b/src/fighter/sonic/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "sonic", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn sonic_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/szerosuit/acmd/escape.rs
+++ b/src/fighter/szerosuit/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "szerosuit", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn szerosuit_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/tantan/acmd/escape.rs
+++ b/src/fighter/tantan/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "tantan", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn tantan_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/template/acmd/escape.rs
+++ b/src/fighter/template/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "template", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn template_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/toonlink/acmd/escape.rs
+++ b/src/fighter/toonlink/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "toonlink", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn toonlink_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/trail/acmd/escape.rs
+++ b/src/fighter/trail/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "trail", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn trail_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/wario/acmd/escape.rs
+++ b/src/fighter/wario/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "wario", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn wario_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/wiifit/acmd/escape.rs
+++ b/src/fighter/wiifit/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "wiifit", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn wiifit_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/wolf/acmd/escape.rs
+++ b/src/fighter/wolf/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "wolf", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn wolf_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/yoshi/acmd/escape.rs
+++ b/src/fighter/yoshi/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "yoshi", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn yoshi_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/younglink/acmd/escape.rs
+++ b/src/fighter/younglink/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "younglink", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn younglink_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }

--- a/src/fighter/zelda/acmd/escape.rs
+++ b/src/fighter/zelda/acmd/escape.rs
@@ -2,7 +2,7 @@ use crate::imports::acmd_imports::*;
 
 #[acmd_script( agent = "zelda", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn zelda_escapeairslide(fighter: &mut L2CAgentBase) {
-    frame(fighter.lua_state_agent, 17.0);
+    frame(fighter.lua_state_agent, 15.0);
     if macros::is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY);
     }


### PR DESCRIPTION
Reworks Air Dash to make characters within an Air Dash Tier to have actually similar Air Dashes. This makes it so the only fighter-specific factor influencing your Air Dash is your gravity and fall speed.

- Very slightly reduces distance of all Air Dashes, except for Ridley and Mewtwo. Will probably seem unnoticeable in practice.
- Gravity kicks in sooner (17 > 15, matching the frame you can attack out of it).
- - This change does not affect Teleport Air Dashes (Mewtwo).
- Air Drift has been universally lowered to 0.02 to disallow Air Dashing horizontally, then retreating back immediately (ex. Yoshi, Wario, etc).
- The amount of speed kept out of the initial portion of the Air Dash, before gravity kicks in, is more or less depending on Air Dash tier.