### PR TITLE
Jumping Adjustments

### DIFF
--- a/src/fighter/common/frame.rs
+++ b/src/fighter/common/frame.rs
@@ -72,36 +72,36 @@ unsafe fn special_jump_stick_flick(fighter: &mut L2CFighterCommon) {
     }
 }
 
-unsafe fn super_jump_gravity(fighter: &mut L2CFighterCommon) {
-    if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_JUMP_MINI)
-    && VarModule::is_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP) {
-        let super_jump_frame = VarModule::get_float(fighter.battle_object, fighter::instance::float::SUPER_JUMP_FRAME);
-        if fighter.global_table[STATUS_FRAME].get_f32() >= 10.0 - super_jump_frame {
-            let air_accel_y = WorkModule::get_param_float(fighter.module_accessor, hash40("air_accel_y"), 0);
-            sv_kinetic_energy!(
-                set_accel,
-                fighter,
-                FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
-                -air_accel_y
-            );
-            VarModule::off_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP);
-            VarModule::set_float(fighter.battle_object, fighter::instance::float::SUPER_JUMP_FRAME, 0.0);
-        }
-        else {
-            fighter.clear_lua_stack();
-            lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-            let gravity_accel = sv_kinetic_energy::get_accel_y(fighter.lua_state_agent);
-            if gravity_accel != -param::jump::super_jump_gravity {
-                sv_kinetic_energy!(
-                    set_accel,
-                    fighter,
-                    FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
-                    -param::jump::super_jump_gravity
-                );
-            }
-        }
-    }
-}
+// unsafe fn super_jump_gravity(fighter: &mut L2CFighterCommon) {
+//     if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_JUMP_MINI)
+//     && VarModule::is_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP) {
+//         let super_jump_frame = VarModule::get_float(fighter.battle_object, fighter::instance::float::SUPER_JUMP_FRAME);
+//         if fighter.global_table[STATUS_FRAME].get_f32() >= 10.0 - super_jump_frame {
+//             let air_accel_y = WorkModule::get_param_float(fighter.module_accessor, hash40("air_accel_y"), 0);
+//             sv_kinetic_energy!(
+//                 set_accel,
+//                 fighter,
+//                 FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+//                 -air_accel_y
+//             );
+//             VarModule::off_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP);
+//             VarModule::set_float(fighter.battle_object, fighter::instance::float::SUPER_JUMP_FRAME, 0.0);
+//         }
+//         else {
+//             fighter.clear_lua_stack();
+//             lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+//             let gravity_accel = sv_kinetic_energy::get_accel_y(fighter.lua_state_agent);
+//             if gravity_accel != -param::jump::super_jump_gravity {
+//                 sv_kinetic_energy!(
+//                     set_accel,
+//                     fighter,
+//                     FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+//                     -param::jump::super_jump_gravity
+//                 );
+//             }
+//         }
+//     }
+// }
 
 // Use this for general per-frame fighter-level hooks
 #[fighter_frame_callback( main )]
@@ -112,7 +112,7 @@ fn common_fighter_frame(fighter: &mut L2CFighterCommon) {
             fgc_frame(fighter);
             hit_cancel_frame_set(fighter);
             special_jump_stick_flick(fighter);
-            super_jump_gravity(fighter);
+            // super_jump_gravity(fighter);
         }
     }
 }

--- a/src/fighter/common/frame.rs
+++ b/src/fighter/common/frame.rs
@@ -6,10 +6,9 @@ use {
         app::{lua_bind::*, *},
         lib::lua_const::*
     },
-    smash_script::*,
     smashline::*,
     custom_var::*,
-    super::{fgc::*, param},
+    super::fgc::*,
     wubor_utils::{vars::*, table_const::*}
 };
 
@@ -72,37 +71,6 @@ unsafe fn special_jump_stick_flick(fighter: &mut L2CFighterCommon) {
     }
 }
 
-// unsafe fn super_jump_gravity(fighter: &mut L2CFighterCommon) {
-//     if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_JUMP_MINI)
-//     && VarModule::is_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP) {
-//         let super_jump_frame = VarModule::get_float(fighter.battle_object, fighter::instance::float::SUPER_JUMP_FRAME);
-//         if fighter.global_table[STATUS_FRAME].get_f32() >= 10.0 - super_jump_frame {
-//             let air_accel_y = WorkModule::get_param_float(fighter.module_accessor, hash40("air_accel_y"), 0);
-//             sv_kinetic_energy!(
-//                 set_accel,
-//                 fighter,
-//                 FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
-//                 -air_accel_y
-//             );
-//             VarModule::off_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP);
-//             VarModule::set_float(fighter.battle_object, fighter::instance::float::SUPER_JUMP_FRAME, 0.0);
-//         }
-//         else {
-//             fighter.clear_lua_stack();
-//             lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-//             let gravity_accel = sv_kinetic_energy::get_accel_y(fighter.lua_state_agent);
-//             if gravity_accel != -param::jump::super_jump_gravity {
-//                 sv_kinetic_energy!(
-//                     set_accel,
-//                     fighter,
-//                     FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
-//                     -param::jump::super_jump_gravity
-//                 );
-//             }
-//         }
-//     }
-// }
-
 // Use this for general per-frame fighter-level hooks
 #[fighter_frame_callback( main )]
 fn common_fighter_frame(fighter: &mut L2CFighterCommon) {
@@ -112,7 +80,6 @@ fn common_fighter_frame(fighter: &mut L2CFighterCommon) {
             fgc_frame(fighter);
             hit_cancel_frame_set(fighter);
             special_jump_stick_flick(fighter);
-            // super_jump_gravity(fighter);
         }
     }
 }

--- a/src/fighter/common/param.rs
+++ b/src/fighter/common/param.rs
@@ -13,7 +13,6 @@ pub mod jump {
     pub const special_jump_control_mul : f32 = 0.5;
     pub const hyper_hop_air_speed_x_stable_mul : f32 = 1.45;
     pub const super_jump_speed_x_mul : f32 = 0.8;
-    pub const super_jump_gravity : f32 = 0.27;
 }
 
 pub mod damage {

--- a/src/fighter/common/param.rs
+++ b/src/fighter/common/param.rs
@@ -13,7 +13,6 @@ pub mod jump {
     pub const special_jump_control_mul : f32 = 0.5;
     pub const hyper_hop_air_speed_x_stable_mul : f32 = 1.45;
     pub const super_jump_speed_x_mul : f32 = 0.8;
-    pub const super_jump_speed_y_init : f32 = 1.825;
     pub const super_jump_gravity : f32 = 0.27;
 }
 

--- a/src/fighter/common/status/jump.rs
+++ b/src/fighter/common/status/jump.rs
@@ -136,18 +136,6 @@ unsafe fn status_jump_sub(fighter: &mut L2CFighterCommon, param_1: L2CValue, par
 
 #[skyline::hook(replace = L2CFighterCommon_status_Jump_Main)]
 unsafe fn status_jump_main(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if VarModule::is_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP)
-    && fighter.global_table[STATUS_FRAME].get_f32() >= 9.0 {
-        let air_accel_y = WorkModule::get_param_float(fighter.module_accessor, hash40("air_accel_y"), 0);
-        sv_kinetic_energy!(
-            set_accel,
-            fighter,
-            FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
-            -air_accel_y
-        );
-        VarModule::off_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP);
-        VarModule::set_float(fighter.battle_object, fighter::instance::float::SUPER_JUMP_FRAME, 0.0);
-    }
     if fighter.sub_transition_group_check_air_cliff().get_bool() {
         return 1.into();
     }
@@ -172,30 +160,8 @@ unsafe fn bind_address_call_status_end_jump(fighter: &mut L2CFighterCommon, _age
 }
 
 #[skyline::hook(replace = L2CFighterCommon_status_end_Jump)]
-unsafe fn status_end_jump(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if VarModule::is_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP) {
-        if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_JUMP_MINI) {
-            let status = fighter.global_table[STATUS_KIND].get_i32();
-            if status == *FIGHTER_STATUS_KIND_ATTACK_AIR
-            || status == *FIGHTER_STATUS_KIND_ESCAPE_AIR {
-                let frame = fighter.global_table[STATUS_FRAME].get_f32();
-                VarModule::set_float(fighter.battle_object, fighter::instance::float::SUPER_JUMP_FRAME, frame);
-            }
-            else {
-                let speed_y = KineticModule::get_sum_speed_y(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
-                sv_kinetic_energy!(
-                    set_speed,
-                    fighter,
-                    FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
-                    speed_y * 0.69
-                );
-                VarModule::off_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP);
-            }
-        }
-        else {
-            VarModule::off_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP);
-        }
-    }
+unsafe fn status_end_jump(_fighter: &mut L2CFighterCommon) -> L2CValue {
+    // VarModule::off_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP);
     0.into()
 }
 

--- a/src/fighter/common/status/jump.rs
+++ b/src/fighter/common/status/jump.rs
@@ -1,5 +1,6 @@
 use crate::imports::status_imports::*;
 use super::super::param;
+use std::arch::asm;
 
 #[skyline::hook(replace = L2CFighterCommon_status_Jump_sub)]
 unsafe fn status_jump_sub(fighter: &mut L2CFighterCommon, param_1: L2CValue, param_2: L2CValue) -> L2CValue {
@@ -176,7 +177,6 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
     }
 }
 
-// Removes Accelerated Full Hops except for specific statuses.
 #[skyline::hook(offset = 0x6d2158, inline)]
 unsafe fn jump_momentum_initial_jump_check(ctx: &mut skyline::hooks::InlineCtx) {
     let module_accessor = *ctx.registers[19].x.as_ref() as *mut BattleObjectModuleAccessor;
@@ -188,15 +188,17 @@ unsafe fn jump_momentum_initial_jump_check(ctx: &mut skyline::hooks::InlineCtx) 
         let sonic = kind == *FIGHTER_KIND_SONIC && status == *FIGHTER_SONIC_STATUS_KIND_SPECIAL_HI_JUMP;
         let rockman = kind == *FIGHTER_KIND_ROCKMAN && status == *FIGHTER_ROCKMAN_STATUS_KIND_SPECIAL_HI_JUMP;
         if !sonic && !rockman {
-            *ctx.registers[21].w.as_mut() = 0;
+            asm!("mov w21, #0x0");
         }
     }
+    asm!("cmp w21, #0x6")
 }
 
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
 
-    // skyline::patching::Patch::in_text(0x6d2158).data(0x52800015u32);
+    // Removes Accelerated Full Hops except for specific statuses.
+    skyline::patching::Patch::in_text(0x6d2158).nop();
     skyline::install_hooks!(
         jump_momentum_initial_jump_check
     );

--- a/src/fighter/common/status/jump.rs
+++ b/src/fighter/common/status/jump.rs
@@ -178,7 +178,4 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
 
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
-
-    // Removes Accelerated Full Hops.
-    skyline::patching::Patch::in_text(0x6d2158).data(0x52800015u32);
 }

--- a/src/fighter/common/status/jump.rs
+++ b/src/fighter/common/status/jump.rs
@@ -251,4 +251,7 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
 
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
+
+    // Removes Accelerated Fullhops Jumps
+    skyline::patching::Patch::in_text(0x6d2158).data(0x52800015u32);
 }

--- a/src/fighter/common/status/jump_squat.rs
+++ b/src/fighter/common/status/jump_squat.rs
@@ -36,19 +36,6 @@ unsafe fn jump_squat_check_special_jump(fighter: &mut L2CFighterCommon) {
     else {
         VarModule::off_flag(fighter.battle_object, fighter::instance::flag::SUPER_JUMP);
     }
-    // let pickel = fighter.global_table[KIND].get_i32() == *FIGHTER_KIND_PICKEL
-    // && [
-    //     *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N1_JUMP_SQUAT,
-    //     *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N3_JUMP_SQUAT
-    // ].contains(&fighter.global_table[STATUS_KIND].get_i32());
-    // let kirby = fighter.global_table[KIND].get_i32() == *FIGHTER_KIND_KIRBY
-    // && [
-    //     *FIGHTER_KIRBY_STATUS_KIND_PICKEL_SPECIAL_N1_JUMP_SQUAT,
-    //     *FIGHTER_KIRBY_STATUS_KIND_PICKEL_SPECIAL_N3_JUMP_SQUAT
-    // ].contains(&fighter.global_table[STATUS_KIND].get_i32());
-    // if pickel || kirby {
-    //     VarModule::off_flag(fighter.battle_object, commons::instance::flag::SUPER_JUMP);
-    // }
 }
 
 #[skyline::hook(replace = L2CFighterCommon_status_JumpSquat_common)]

--- a/src/system.rs
+++ b/src/system.rs
@@ -49,6 +49,7 @@ pub fn install() {
     fighter_util::install();
     menu::install();
     music::install();
+    
     // Removes Phantom Hits
     skyline::patching::Patch::in_text(0x3e6ce8).data(0x14000012u32);
 }

--- a/src/system/get_param.rs
+++ b/src/system/get_param.rs
@@ -14,7 +14,19 @@ pub unsafe fn get_param_float_replace(module: u64, param_type: u64, param_hash: 
     let module_accessor = &mut *(*((module as *mut u64).offset(1)) as *mut BattleObjectModuleAccessor);
     let category = utility::get_category(&mut *module_accessor);
     let kind = utility::get_kind(&mut *module_accessor);
-    if category == *BATTLE_OBJECT_CATEGORY_WEAPON {
+    if category == *BATTLE_OBJECT_CATEGORY_FIGHTER {
+        let object = MiscModule::get_battle_object_from_id(module_accessor.battle_object_id);
+        if [
+            hash40("jump_y")
+        ].contains(&param_type) {
+            let mut mul = 1.0;
+            if VarModule::is_flag(object, vars::fighter::instance::flag::SUPER_JUMP) {
+                mul *= 1.2;
+            }
+            return ret * mul;
+        }
+    }
+    else if category == *BATTLE_OBJECT_CATEGORY_WEAPON {
         if kind == *WEAPON_KIND_KAMUI_RYUSENSYA {
             let otarget_id = WorkModule::get_int(module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_ACTIVATE_FOUNDER_ID) as u32;
             if sv_battle_object::is_active(otarget_id)

--- a/src/system/get_param.rs
+++ b/src/system/get_param.rs
@@ -21,7 +21,7 @@ pub unsafe fn get_param_float_replace(module: u64, param_type: u64, param_hash: 
         ].contains(&param_type) {
             let mut mul = 1.0;
             if VarModule::is_flag(object, vars::fighter::instance::flag::SUPER_JUMP) {
-                mul *= 1.2;
+                mul *= 1.4;
             }
             return ret * mul;
         }


### PR DESCRIPTION
Changelog

Super Jumping:
Now uses a param hook to increase jump height.
Super Jump height is now 1.4x your Full Hop height.
Increased gravity during Super Jumps was removed.
Now functions properly when your stats have changed, like with the Bunny Hood or with Monado Jump active.