### PR TITLE
Removes Accelerated Full Hops

### DIFF
--- a/src/fighter/common/status/jump.rs
+++ b/src/fighter/common/status/jump.rs
@@ -1,5 +1,6 @@
 use crate::imports::status_imports::*;
 use super::super::param;
+use std::arch::asm;
 
 #[skyline::hook(replace = L2CFighterCommon_status_Jump_sub)]
 unsafe fn status_jump_sub(fighter: &mut L2CFighterCommon, param_1: L2CValue, param_2: L2CValue) -> L2CValue {
@@ -176,6 +177,36 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
     }
 }
 
+#[skyline::hook(offset = 0x6d2158, inline)]
+unsafe fn jump_momentum_initial_jump_check(ctx: &mut skyline::hooks::InlineCtx) {
+    let module_accessor = *ctx.registers[19].x.as_ref() as *mut BattleObjectModuleAccessor;
+    let object_id = (*module_accessor).battle_object_id;
+    let category = sv_battle_object::category(object_id);
+    let speed_up = if category == *BATTLE_OBJECT_CATEGORY_FIGHTER {
+        let kind = sv_battle_object::kind(object_id);
+        let status = StatusModule::status_kind(module_accessor);
+        let sonic = kind == *FIGHTER_KIND_SONIC && status == *FIGHTER_SONIC_STATUS_KIND_SPECIAL_HI_JUMP;
+        let rockman = kind == *FIGHTER_KIND_ROCKMAN && status == *FIGHTER_ROCKMAN_STATUS_KIND_SPECIAL_HI_JUMP;
+        sonic || rockman
+    }
+    else {
+        false
+    };
+    // println!("w21: {:#x}", *ctx.registers[21].w.as_mut());
+    if speed_up {
+        asm!("cmp w21, #0x6")
+    }
+    else {
+        asm!("cmp w21, #0xFFF")
+    }
+}
+
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
+
+    // Removes Accelerated Full Hops except for specific statuses.
+    skyline::patching::Patch::in_text(0x6d2158).nop();
+    skyline::install_hooks!(
+        jump_momentum_initial_jump_check
+    );
 }

--- a/src/system/get_param.rs
+++ b/src/system/get_param.rs
@@ -17,11 +17,11 @@ pub unsafe fn get_param_float_replace(module: u64, param_type: u64, param_hash: 
     if category == *BATTLE_OBJECT_CATEGORY_FIGHTER {
         let object = MiscModule::get_battle_object_from_id(module_accessor.battle_object_id);
         if [
-            hash40("jump_y")
+            hash40("jump_speed_y")
         ].contains(&param_type) {
             let mut mul = 1.0;
             if VarModule::is_flag(object, vars::fighter::instance::flag::SUPER_JUMP) {
-                mul *= 1.4;
+                mul *= 1.2;
             }
             return ret * mul;
         }


### PR DESCRIPTION
This was going to be a part of the previous Jump Adjustments PR but I couldn't get it to work in time.

This removes Ultimate's feature that increases your upwards speed on full hops.