### PR TITLE
Complete Shield Rework

### DIFF
--- a/WuBor-Utils/src/table_const.rs
+++ b/WuBor-Utils/src/table_const.rs
@@ -12,17 +12,17 @@ pub const STATUS_KIND_INTERRUPT:           i32 = 0x9;
 pub const PREV_STATUS_KIND:                i32 = 0xA;
 pub const STATUS_KIND:                     i32 = 0xB;
 pub const STATUS_COUNT:                    i32 = 0xC;
- 
+
 pub const STATUS_FRAME:                    i32 = 0xE;
 pub const STATUS_FRAME_NO_INTERP:          i32 = 0xF;
- 
+
 pub const SUB_STATUS3:                     i32 = 0x13;
 pub const SUB_STATUS2:                     i32 = 0x14;
 pub const SUB_STATUS:                      i32 = 0x15;
 pub const SITUATION_KIND:                  i32 = 0x16;
 pub const PREV_SITUATION_KIND:             i32 = 0x17;
 pub const PREV_STATUS_FRAME:               i32 = 0x18;
- 
+
 pub const STICK_X:                         i32 = 0x1A;
 pub const STICK_Y:                         i32 = 0x1B;
 pub const FLICK_X:                         i32 = 0x1C;

--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -54,7 +54,7 @@ pub mod fighter {
             pub const DISABLE_SPECIAL_S : i32 = 0x0001;
             pub const DISABLE_SPECIAL_HI : i32 = 0x0002;
             pub const DISABLE_SPECIAL_LW : i32 = 0x0003;
-            pub const GUARD_OFF_ATTACK_CANCEL : i32 = 0x0004;
+            // pub const GUARD_OFF_ATTACK_CANCEL : i32 = 0x0004;
             // pub const IS_FGC : i32 = 0x0005;
             pub const CANCEL_ESCAPE_TO_ESCAPE_FB : i32 = 0x0006;
             pub const SUPER_JUMP : i32 = 0x0007;
@@ -137,12 +137,6 @@ pub mod dash {
 pub mod damage_fly_roll {
     pub mod flag {
         pub const DISABLE_PASSIVE : i32 = 0x1050;
-    }
-}
-
-pub mod guard_off {
-    pub mod int {
-        pub const ATTACK_CANCEL_FRAME : i32 = 0x1050;
     }
 }
 

--- a/src/fighter/common/param.rs
+++ b/src/fighter/common/param.rs
@@ -1,7 +1,6 @@
 #![allow(non_upper_case_globals)]
 
 pub mod shield {
-    pub const guard_off_attack_cancel_frame : i32 = 5;
     pub const guard_off_invalid_capture_frame_add : i32 = 3;
 }
 

--- a/src/fighter/common/status/dash.rs
+++ b/src/fighter/common/status/dash.rs
@@ -612,7 +612,6 @@ unsafe extern "C" fn fgc_dashback_main_loop(fighter: &mut L2CFighterCommon) -> L
         return true.into();
     }
 
-
     if fighter.sub_transition_group_check_special_command().get_bool() {
         return 1.into();
     }

--- a/src/fighter/common/status/guard.rs
+++ b/src/fighter/common/status/guard.rs
@@ -12,13 +12,13 @@ unsafe fn sub_guard_cont_pre(fighter: &mut L2CFighterCommon) {
     }
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH);
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START);
-    // WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI);
+    WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI);
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE);
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_F);
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_B);
-    if GroundModule::is_passable_ground(fighter.module_accessor) {
-        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_PASS);
-    }
+    // if GroundModule::is_passable_ground(fighter.module_accessor) {
+    //     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_PASS);
+    // }
     WorkModule::enable_transition_term_group(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_GROUP_CHK_GROUND_JUMP);
 }
 
@@ -48,7 +48,8 @@ unsafe fn sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue {
         || (fighter.global_table[PAD_FLAG].get_i32() & *FIGHTER_PAD_FLAG_ATTACK_TRIGGER == 0
         && fighter.global_table[CMD_CAT3].get_i32() & (*FIGHTER_PAD_CMD_CAT3_ITEM_LIGHT_THROW_HI | *FIGHTER_PAD_CMD_CAT3_ITEM_LIGHT_THROW_HI4) != 0) {
             if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
-                fighter.change_status(FIGHTER_STATUS_KIND_ITEM_THROW.into(), false.into());
+                // fighter.change_status(FIGHTER_STATUS_KIND_ITEM_THROW.into(), false.into());
+                fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), false.into());
                 return true.into();
             }
         }
@@ -85,16 +86,16 @@ unsafe fn sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue {
             fighter.change_status(FIGHTER_STATUS_KIND_ESCAPE_B.into(), true.into());
             return true.into();
         }
-        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_PASS)
-        && fighter.global_table[CMD_CAT2].get_i32() & (
-            *FIGHTER_PAD_CMD_CAT2_FLAG_GUARD_TO_PASS | *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI |
-            *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L | *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R |
-            *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW
-        ) != 0
-        && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
-            fighter.change_status(FIGHTER_STATUS_KIND_PASS.into(), true.into());
-            return true.into();
-        }
+        // if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_PASS)
+        // && fighter.global_table[CMD_CAT2].get_i32() & (
+        //     *FIGHTER_PAD_CMD_CAT2_FLAG_GUARD_TO_PASS | *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI |
+        //     *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L | *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R |
+        //     *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW
+        // ) != 0
+        // && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        //     fighter.change_status(FIGHTER_STATUS_KIND_PASS.into(), true.into());
+        //     return true.into();
+        // }
     }
     if fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() == *FIGHTER_STATUS_KIND_GUARD_ON
     && fighter.global_table[PREV_STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_RUN
@@ -105,33 +106,77 @@ unsafe fn sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue {
         fighter.change_status(FIGHTER_STATUS_KIND_CATCH_DASH.into(), true.into());
         return true.into();
     }
-    if !fighter.check_guard_attack_special_hi(check_guard_hold.into()).get_bool() {
-        if WorkModule::get_int(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_INVALID_CATCH_FRAME) == 0 {
-            if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH)
-            && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0
-            && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
-            && !ItemModule::is_have_item(fighter.module_accessor, 0) {
-                fighter.change_status(FIGHTER_STATUS_KIND_CATCH.into(), true.into());
+    if fighter.check_guard_attack_special_hi(check_guard_hold.into()).get_bool() {
+        return true.into();
+    }
+    if WorkModule::get_int(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_INVALID_CATCH_FRAME) == 0 {
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH)
+        && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0
+        && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
+        && !ItemModule::is_have_item(fighter.module_accessor, 0) {
+            // fighter.change_status(FIGHTER_STATUS_KIND_CATCH.into(), true.into());
+            fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), false.into());
+            return true.into();
+        }
+    }
+    if !check_guard_hold {
+        // if fighter.sub_transition_group_check_ground_jump().get_bool() {
+        //     return true.into();
+        // }
+        if fighter.sub_check_button_jump().get_bool()
+        || fighter.sub_check_button_frick().get_bool() {
+            fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), false.into());
+            return true.into();
+        }
+    }
+    false.into()
+}
+
+#[skyline::hook(replace = L2CFighterCommon_check_guard_attack_special_hi)]
+unsafe fn check_guard_attack_special_hi(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
+    let cat1 = fighter.global_table[CMD_CAT1].get_i32();
+    if !param_1.get_bool() {
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START)
+        && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_HI4 != 0
+        && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
+        && !ItemModule::is_have_item(fighter.module_accessor, 0) {
+            ControlModule::clear_command_one(fighter.module_accessor, 0, 0x1d); // FIGHTER_PAD_CMD_CAT1_CATCH
+            fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), false.into());
+            return true.into();
+        }
+    }
+    let stick_y = fighter.global_table[STICK_Y].get_f32();
+    let special_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("special_stick_y"));
+    let flick_y = fighter.global_table[FLICK_Y].get_i32();
+    let jump_flick_y = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("jump_flick_y"));
+    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_SPECIAL_HI)
+    || stick_y > special_stick_y && flick_y < jump_flick_y {
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI)
+        && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0 {
+            let cont = if fighter.global_table[CHECK_SPECIAL_HI_UNIQ].get_bool() {
+                let callable: extern "C" fn(&mut L2CFighterCommon) -> L2CValue = std::mem::transmute(fighter.global_table[CHECK_SPECIAL_HI_UNIQ].get_ptr());
+                callable(fighter).get_bool()
+            }
+            else {
+                true
+            };
+            if cont {
+                // fighter.change_status(FIGHTER_STATUS_KIND_SPECIAL_HI.into(), true.into());
+                fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), false.into());
                 return true.into();
             }
         }
-        if !check_guard_hold {
-            if fighter.sub_transition_group_check_ground_jump().get_bool() {
-                return true.into();
-            }
-        }
-        false.into()
+        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_SPECIAL_HI);
     }
-    else {
-        true.into()
-    }
+    false.into()
 }
 
 fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hooks!(
             sub_guard_cont_pre,
-            sub_guard_cont
+            sub_guard_cont,
+            check_guard_attack_special_hi
         );
     }
 }

--- a/src/fighter/common/status/guard.rs
+++ b/src/fighter/common/status/guard.rs
@@ -2,7 +2,7 @@ use crate::imports::status_imports::*;
 
 #[skyline::hook(replace = L2CFighterCommon_sub_guard_cont_pre)]
 unsafe fn sub_guard_cont_pre(fighter: &mut L2CFighterCommon) {
-    // WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ITEM_THROW_GUARD);
+    WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ITEM_THROW_GUARD);
     if fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() == *FIGHTER_STATUS_KIND_GUARD_ON
     && fighter.global_table[PREV_STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_RUN {
         WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH_TURN);
@@ -11,15 +11,19 @@ unsafe fn sub_guard_cont_pre(fighter: &mut L2CFighterCommon) {
         WorkModule::set_int(fighter.module_accessor, catch_dash_frame, *FIGHTER_STATUS_GUARD_ON_WORK_INT_CATCH_FRAME);
     }
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH);
-    WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START);
-    WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI);
-    WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE);
-    WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_F);
-    WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_B);
+    // WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START);
+    // WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI);
+    // WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE);
+    // WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_F);
+    // WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_B);
     // if GroundModule::is_passable_ground(fighter.module_accessor) {
     //     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_PASS);
     // }
     WorkModule::enable_transition_term_group(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_GROUP_CHK_GROUND_JUMP);
+    WorkModule::enable_transition_term_group(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_GROUP_CHK_GROUND_ATTACK);
+    WorkModule::enable_transition_term_group(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_GROUP_CHK_GROUND_SPECIAL);
+    WorkModule::enable_transition_term_group(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_GROUP_CHK_GROUND_ITEM);
+    WorkModule::enable_transition_term_group(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_GROUP_CHK_GROUND_ESCAPE);
 }
 
 #[skyline::hook(replace = L2CFighterCommon_sub_guard_cont)]
@@ -31,11 +35,11 @@ unsafe fn sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue {
         return true.into();
     }
     let check_guard_hold = fighter.check_guard_hold().get_bool();
-    if !check_guard_hold {
-        if fighter.sub_transition_group_check_ground_jump_mini_attack().get_bool() {
-            return true.into();
-        }
-    }
+    // if !check_guard_hold {
+    //     if fighter.sub_transition_group_check_ground_jump_mini_attack().get_bool() {
+    //         return true.into();
+    //     }
+    // }
     if !check_guard_hold
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ITEM_THROW_GUARD)
     && ItemModule::is_have_item(fighter.module_accessor, 0) && {
@@ -49,24 +53,58 @@ unsafe fn sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue {
         && fighter.global_table[CMD_CAT3].get_i32() & (*FIGHTER_PAD_CMD_CAT3_ITEM_LIGHT_THROW_HI | *FIGHTER_PAD_CMD_CAT3_ITEM_LIGHT_THROW_HI4) != 0) {
             if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
                 // fighter.change_status(FIGHTER_STATUS_KIND_ITEM_THROW.into(), false.into());
+                ControlModule::clear_command_one(fighter.module_accessor, 0, 0x1d); // FIGHTER_PAD_CMD_CAT1_CATCH
                 fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), false.into());
                 return true.into();
             }
         }
     }
     if fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() == *FIGHTER_STATUS_KIND_GUARD_ON
-    && fighter.global_table[PREV_STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_RUN
-    && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH_TURN) && {
-        let stick_x = fighter.global_table[STICK_X].get_f32();
-        let lr = PostureModule::lr(fighter.module_accessor);
-        let turn_run_stick_x = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("turn_run_stick_x"));
-        stick_x * lr <= turn_run_stick_x
-    } && ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_ATTACK)
-    && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
-    && !ItemModule::is_have_item(fighter.module_accessor, 0) {
-        fighter.change_status(FIGHTER_STATUS_KIND_CATCH_TURN.into(), true.into());
+    && fighter.global_table[PREV_STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_RUN {
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH_TURN) && {
+            let stick_x = fighter.global_table[STICK_X].get_f32();
+            let lr = PostureModule::lr(fighter.module_accessor);
+            let turn_run_stick_x = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("turn_run_stick_x"));
+            stick_x * lr <= turn_run_stick_x
+        } && ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_ATTACK)
+        && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
+        && !ItemModule::is_have_item(fighter.module_accessor, 0) {
+            fighter.change_status(FIGHTER_STATUS_KIND_CATCH_TURN.into(), true.into());
+            return true.into();
+        }
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH_DASH)
+        && ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_ATTACK)
+        && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
+        && !ItemModule::is_have_item(fighter.module_accessor, 0) {
+            fighter.change_status(FIGHTER_STATUS_KIND_CATCH_DASH.into(), true.into());
+            return true.into();
+        }
+    }
+    if fighter.check_guard_attack_special_hi(check_guard_hold.into()).get_bool() {
         return true.into();
     }
+    if !check_guard_hold {
+        if ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) {
+            ControlModule::clear_command_one(fighter.module_accessor, 0, 0x1d); // FIGHTER_PAD_CMD_CAT1_CATCH
+            fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), false.into());
+            return true.into();
+        }
+        if fighter.sub_check_button_jump().get_bool()
+        || fighter.sub_check_button_frick().get_bool() {
+            fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), false.into());
+            return true.into();
+        }
+    }
+    // if WorkModule::get_int(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_INVALID_CATCH_FRAME) == 0 {
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH)
+        && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0
+        && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
+        && !ItemModule::is_have_item(fighter.module_accessor, 0) {
+            // fighter.change_status(FIGHTER_STATUS_KIND_CATCH.into(), true.into());
+            fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), false.into());
+            return true.into();
+        }
+    // }
     if !check_guard_hold {
         if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE)
         && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_STICK_ESCAPE != 0
@@ -97,45 +135,13 @@ unsafe fn sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue {
         //     return true.into();
         // }
     }
-    if fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() == *FIGHTER_STATUS_KIND_GUARD_ON
-    && fighter.global_table[PREV_STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_RUN
-    && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH_DASH)
-    && ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_ATTACK)
-    && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
-    && !ItemModule::is_have_item(fighter.module_accessor, 0) {
-        fighter.change_status(FIGHTER_STATUS_KIND_CATCH_DASH.into(), true.into());
-        return true.into();
-    }
-    if fighter.check_guard_attack_special_hi(check_guard_hold.into()).get_bool() {
-        return true.into();
-    }
-    if WorkModule::get_int(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_INVALID_CATCH_FRAME) == 0 {
-        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH)
-        && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0
-        && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
-        && !ItemModule::is_have_item(fighter.module_accessor, 0) {
-            // fighter.change_status(FIGHTER_STATUS_KIND_CATCH.into(), true.into());
-            fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), false.into());
-            return true.into();
-        }
-    }
-    if !check_guard_hold {
-        // if fighter.sub_transition_group_check_ground_jump().get_bool() {
-        //     return true.into();
-        // }
-        if fighter.sub_check_button_jump().get_bool()
-        || fighter.sub_check_button_frick().get_bool() {
-            fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), false.into());
-            return true.into();
-        }
-    }
     false.into()
 }
 
 #[skyline::hook(replace = L2CFighterCommon_check_guard_attack_special_hi)]
-unsafe fn check_guard_attack_special_hi(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
+unsafe fn check_guard_attack_special_hi(fighter: &mut L2CFighterCommon, guard_hold: L2CValue) -> L2CValue {
     let cat1 = fighter.global_table[CMD_CAT1].get_i32();
-    if !param_1.get_bool() {
+    if !guard_hold.get_bool() {
         if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START)
         && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_HI4 != 0
         && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND

--- a/src/fighter/common/status/guard_off.rs
+++ b/src/fighter/common/status/guard_off.rs
@@ -93,14 +93,6 @@ unsafe fn sub_guard_off_uniq(fighter: &mut L2CFighterCommon, param_1: L2CValue) 
 #[skyline::hook(replace = L2CFighterCommon_sub_status_guard_off_main_common_cancel)]
 unsafe fn sub_status_guard_off_main_common_cancel(fighter: &mut L2CFighterCommon) -> L2CValue {
     if CancelModule::is_enable_cancel(fighter.module_accessor) {
-        if fighter.sub_check_button_jump().get_bool()
-        || fighter.sub_check_button_frick().get_bool() {
-            if fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0 {
-                WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_MINI_ATTACK);
-            }
-            fighter.change_status(FIGHTER_STATUS_KIND_JUMP_SQUAT.into(), true.into());
-            return true.into();
-        }
         if fighter.sub_wait_ground_check_common(false.into()).get_bool() {
             return true.into();
         }

--- a/src/fighter/common/status/guard_off.rs
+++ b/src/fighter/common/status/guard_off.rs
@@ -93,6 +93,14 @@ unsafe fn sub_guard_off_uniq(fighter: &mut L2CFighterCommon, param_1: L2CValue) 
 #[skyline::hook(replace = L2CFighterCommon_sub_status_guard_off_main_common_cancel)]
 unsafe fn sub_status_guard_off_main_common_cancel(fighter: &mut L2CFighterCommon) -> L2CValue {
     if CancelModule::is_enable_cancel(fighter.module_accessor) {
+        if fighter.sub_check_button_jump().get_bool()
+        || fighter.sub_check_button_frick().get_bool() {
+            if fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0 {
+                WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_MINI_ATTACK);
+            }
+            fighter.change_status(FIGHTER_STATUS_KIND_JUMP_SQUAT.into(), true.into());
+            return true.into();
+        }
         if fighter.sub_wait_ground_check_common(false.into()).get_bool() {
             return true.into();
         }

--- a/src/fighter/common/status/guard_off.rs
+++ b/src/fighter/common/status/guard_off.rs
@@ -1,5 +1,4 @@
 use crate::imports::status_imports::*;
-use super::super::param;
 
 #[skyline::hook(replace = L2CFighterCommon_sub_ftStatusUniqProcessGuardOff_initStatus)]
 unsafe fn sub_ftstatusuniqprocessguardoff_initstatus(_fighter: &mut L2CFighterCommon) -> L2CValue {
@@ -61,7 +60,6 @@ unsafe fn status_guardoff_common(fighter: &mut L2CFighterCommon) -> L2CValue {
     // WorkModule::set_int(fighter.module_accessor, just_frame, *FIGHTER_STATUS_GUARD_ON_WORK_INT_JUST_FRAME);
     let guard_off_cancel_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("guard_off_cancel_frame"));
     WorkModule::set_int(fighter.module_accessor, guard_off_cancel_frame, *FIGHTER_STATUS_GUARD_OFF_WORK_INT_CANCEL_FRAME);
-    VarModule::set_int(fighter.battle_object, guard_off::int::ATTACK_CANCEL_FRAME, 0);
     let anim_cancel_frame = FighterMotionModuleImpl::get_cancel_frame(fighter.module_accessor, Hash40::new("guard_off"), true);
     let mut motion_rate = 1.0;
     if 0.0 < guard_off_cancel_frame as f32
@@ -82,12 +80,6 @@ unsafe fn status_guardoff_common(fighter: &mut L2CFighterCommon) -> L2CValue {
 #[skyline::hook(replace = L2CFighterCommon_sub_guard_off_uniq)]
 unsafe fn sub_guard_off_uniq(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
     if param_1.get_bool() {
-        if VarModule::get_int(fighter.battle_object, guard_off::int::ATTACK_CANCEL_FRAME) < param::shield::guard_off_attack_cancel_frame {
-            VarModule::inc_int(fighter.battle_object, guard_off::int::ATTACK_CANCEL_FRAME);
-            if VarModule::get_int(fighter.battle_object, guard_off::int::ATTACK_CANCEL_FRAME) == param::shield::guard_off_attack_cancel_frame {
-                VarModule::on_flag(fighter.battle_object, fighter::instance::flag::GUARD_OFF_ATTACK_CANCEL);
-            }
-        }
         if WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_GUARD_OFF_WORK_INT_CANCEL_FRAME) > 0 {
             WorkModule::dec_int(fighter.module_accessor, *FIGHTER_STATUS_GUARD_OFF_WORK_INT_CANCEL_FRAME);
             if WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_GUARD_OFF_WORK_INT_CANCEL_FRAME) == 0 {
@@ -105,80 +97,21 @@ unsafe fn sub_status_guard_off_main_common_cancel(fighter: &mut L2CFighterCommon
             return true.into();
         }
     }
-    else {
-        if fighter.sub_transition_group_check_ground_jump_mini_attack().get_bool() {
-            return true.into();
-        }
-        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ITEM_THROW_GUARD) {
-            let mut cont = ItemModule::is_have_item(fighter.module_accessor, 0);
-            if cont {
-                fighter.clear_lua_stack();
-                lua_args!(fighter, MA_MSC_ITEM_CHECK_HAVE_ITEM_TRAIT, ITEM_TRAIT_FLAG_THROW);
-                sv_module_access::item(fighter.lua_state_agent);
-                cont = fighter.pop_lua_stack(1).get_bool();
-                if !cont {
-                    fighter.clear_lua_stack();
-                    lua_args!(fighter, MA_MSC_ITEM_CHECK_HAVE_ITEM_TRAIT, ITEM_TRAIT_FLAG_SHOOT);
-                    sv_module_access::item(fighter.lua_state_agent);
-                    cont = fighter.pop_lua_stack(1).get_bool();
-                    if cont {
-                        cont = ItemModule::get_shoot_item_bullet(fighter.module_accessor, 0) <= 0;
-                    }
-                }
-                if cont {
-                    fighter.clear_lua_stack();
-                    lua_args!(fighter, MA_MSC_ITEM_CHECK_HAVE_ITEM_TRAIT, ITEM_TRAIT_FLAG_THROW);
-                    sv_module_access::item(fighter.lua_state_agent);
-                    cont = fighter.pop_lua_stack(1).get_bool();
-                    if !cont
-                    && fighter.global_table[PAD_FLAG].get_i32() & *FIGHTER_PAD_FLAG_ATTACK_TRIGGER != 0
-                    && fighter.global_table[CMD_CAT3].get_i32() & (
-                        *FIGHTER_PAD_CMD_CAT3_ITEM_LIGHT_THROW_HI |
-                        *FIGHTER_PAD_CMD_CAT3_ITEM_LIGHT_THROW_HI4
-                    ) != 0 {
-                        fighter.change_status(FIGHTER_STATUS_KIND_ITEM_THROW.into(), false.into());
-                        return true.into();
-                    }
-                    if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD)
-                    && fighter.global_table[PAD_FLAG].get_i32() & *FIGHTER_PAD_FLAG_ATTACK_TRIGGER == 0
-                    && fighter.global_table[PAD_FLAG].get_i32() & *FIGHTER_PAD_FLAG_ATTACK_TRIGGER != 0
-                    && fighter.global_table[CMD_CAT3].get_i32() & (
-                        *FIGHTER_PAD_CMD_CAT3_ITEM_LIGHT_THROW_HI |
-                        *FIGHTER_PAD_CMD_CAT3_ITEM_LIGHT_THROW_HI4
-                    ) != 0 {
-                        fighter.change_status(FIGHTER_STATUS_KIND_ITEM_THROW.into(), false.into());
-                        return true.into();
-                    }
-                }
-            }
-        }
-        if VarModule::is_flag(fighter.battle_object, fighter::instance::flag::GUARD_OFF_ATTACK_CANCEL) {
-            if fighter.sub_transition_group_check_ground_item().get_bool()
-            || fighter.sub_transition_group_check_ground_catch().get_bool()
-            || fighter.sub_transition_group_check_ground_special().get_bool()
-            || fighter.sub_transition_group_check_ground_attack().get_bool() {
-                return true.into();
-            }
-        }
-    }
     false.into()
 }
 
 #[skyline::hook(replace = L2CFighterCommon_sub_status_guard_off_main_common_control)]
-unsafe fn sub_status_guard_off_main_common_control(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if !fighter.sub_transition_group_check_ground_jump().get_bool() {
-        return false.into();
-    }
+unsafe fn sub_status_guard_off_main_common_control(_fighter: &mut L2CFighterCommon) -> L2CValue {
+    // if !fighter.sub_transition_group_check_ground_jump().get_bool() {
+    //     return false.into();
+    // }
     true.into()
 }
 
 #[skyline::hook(replace = L2CFighterCommon_status_end_GuardOff)]
 unsafe fn status_end_guardoff(fighter: &mut L2CFighterCommon) -> L2CValue {
     ModelModule::set_joint_scale(fighter.module_accessor, Hash40::new("throw"), &Vector3f{x: 1.0, y: 1.0, z: 1.0});
-    WorkModule::unable_transition_term_forbid(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_GUARD_ON);
-    if fighter.global_table[STATUS_KIND].get_i32() != *FIGHTER_STATUS_KIND_JUMP_SQUAT {
-        VarModule::off_flag(fighter.battle_object, fighter::instance::flag::GUARD_OFF_ATTACK_CANCEL);
-    }
+    // WorkModule::unable_transition_term_forbid(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_GUARD_ON);
     0.into()
 }
 

--- a/src/fighter/common/status/guard_off.rs
+++ b/src/fighter/common/status/guard_off.rs
@@ -102,10 +102,10 @@ unsafe fn sub_status_guard_off_main_common_cancel(fighter: &mut L2CFighterCommon
 
 #[skyline::hook(replace = L2CFighterCommon_sub_status_guard_off_main_common_control)]
 unsafe fn sub_status_guard_off_main_common_control(_fighter: &mut L2CFighterCommon) -> L2CValue {
-    // if !fighter.sub_transition_group_check_ground_jump().get_bool() {
-    //     return false.into();
+    // if fighter.sub_transition_group_check_ground_jump().get_bool() {
+    //     return true.into();
     // }
-    true.into()
+    false.into()
 }
 
 #[skyline::hook(replace = L2CFighterCommon_status_end_GuardOff)]

--- a/src/fighter/common/status/jump_squat.rs
+++ b/src/fighter/common/status/jump_squat.rs
@@ -76,20 +76,6 @@ unsafe fn status_jumpsquat_common(fighter: &mut L2CFighterCommon, param_1: L2CVa
         WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ITEM_THROW);
         WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U);
     }
-    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_RESERVE_JUMP_MINI_ATTACK)
-    || [
-        *FIGHTER_STATUS_KIND_GUARD_ON,
-        *FIGHTER_STATUS_KIND_GUARD
-    ].contains(&fighter.global_table[PREV_STATUS_KIND].get_i32())
-    || (fighter.global_table[PREV_STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_GUARD_OFF
-    && !VarModule::is_flag(fighter.battle_object, fighter::instance::flag::GUARD_OFF_ATTACK_CANCEL)) {
-        VarModule::off_flag(fighter.battle_object, fighter::instance::flag::GUARD_OFF_ATTACK_CANCEL);
-        WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI);
-        WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START);
-        WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ITEM_THROW_FORCE);
-        WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ITEM_THROW);
-        WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U);
-    }
 }
 
 #[skyline::hook(replace = L2CFighterCommon_status_JumpSquat_Main)]

--- a/src/fighter/common/status/sub_transitions.rs
+++ b/src/fighter/common/status/sub_transitions.rs
@@ -9,20 +9,19 @@ unsafe fn sub_transition_group_check_ground_jump_mini_attack(fighter: &mut L2CFi
             return callable(fighter);
         }
         let cat1 = fighter.global_table[CMD_CAT1].get_i32();
-        let check_grab = if
+        let check_attack_input = if
             [
                 *FIGHTER_STATUS_KIND_GUARD_ON,
                 *FIGHTER_STATUS_KIND_GUARD,
                 *FIGHTER_STATUS_KIND_GUARD_OFF,
                 *FIGHTER_STATUS_KIND_GUARD_DAMAGE,
             ].contains(&fighter.global_table[STATUS_KIND_INTERRUPT].get_i32()) {
-            cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0
+            cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0 || cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N != 0
         }
         else {
-            cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH == 0
+            cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH == 0 && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N != 0
         };
-        if check_grab
-        && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N != 0
+        if check_attack_input
         && fighter.sub_check_button_jump().get_bool() {
             fighter.change_status_jump_mini_attack(false.into());
             return true.into();

--- a/src/fighter/common/status/sub_transitions.rs
+++ b/src/fighter/common/status/sub_transitions.rs
@@ -30,7 +30,8 @@ unsafe fn sub_transition_group_check_ground_guard(fighter: &mut L2CFighterCommon
             }
         }
         if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_GUARD_ON)
-        && fighter.sub_check_command_guard().get_bool() {
+        && fighter.sub_check_command_guard().get_bool()
+        && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH == 0 {
             fighter.change_status(FIGHTER_STATUS_KIND_GUARD_ON.into(), true.into());
             return true.into();
         }

--- a/wubor-changelog/src/system/engine.md
+++ b/wubor-changelog/src/system/engine.md
@@ -33,6 +33,7 @@ No longer forces a short hop. Release the jump button to perform a Short Hop, or
 * Shield Pushback was also increased by roughly 1.3x.
   * Shield Pushback while Parrying was reduced to 0.
 * Shield Release frames were reduced from 11 frames to 5.
+* It is impossible to shield for 11 frames after the start of Shield Release (6 frames after you're actionable from Shield Release).
 
 ## Out-of-Shield
 Out-of-Shield options have been significantly changed.

--- a/wubor-changelog/src/system/engine.md
+++ b/wubor-changelog/src/system/engine.md
@@ -30,7 +30,7 @@ No longer forces a short hop. Release the jump button to perform a Short Hop, or
 * Parrying has been moved to Shield Startup instead of Shield Release.
 * The Parry window was reduced from 5 to 3 frames.
   * These two changes should make it possible, but difficult to parry multi-hit moves, as many slower multi-hits will require manual represses of Shield.
-* Shield Pushback was also increased by roughly 1.2x.
+* Shield Pushback was also increased by roughly 1.3x.
   * Shield Pushback while Parrying was reduced to 0.
 * Shield Release frames were reduced from 11 frames to 5.
 

--- a/wubor-changelog/src/system/engine.md
+++ b/wubor-changelog/src/system/engine.md
@@ -27,12 +27,21 @@ No longer forces a short hop. Release the jump button to perform a Short Hop, or
 ## Shield
 
 * It is now possible to Shield during Dash and Back Dash (Ryu/Ken/Terry/Kazuya).
-* You can no longer directly use Up Special while in Shield.
 * Parrying has been moved to Shield Startup instead of Shield Release.
 * The Parry window was reduced from 5 to 3 frames.
   * These two changes should make it possible, but difficult to parry multi-hit moves, as many slower multi-hits will require manual represses of Shield.
-* Shield Pushback was also increased by roughly 1.3x.
+* Shield Pushback was also increased by roughly 1.2x.
   * Shield Pushback while Parrying was reduced to 0.
+* Shield Release frames were reduced from 11 frames to 5.
+
+## Out-of-Shield
+Out-of-Shield options have been significantly changed.
+
+* You can no longer directly perform actions out of shield. Performing any action while holding Shield will instead force a Shield Drop first, and then buffer the action.
+  * Spotdodges and Rolls can still be directly performed.
+  * In addition, Grab, Dash Grab, and Turn Grab can still be performed directly while putting up Shield. Performing Grab otherwise will force a Shield Drop first.
+* Using the C-Stick will drop shield and perform whatever the C-Stick is bound to.
+  * Performing angled Tilts or Smash Attacks will require moving the left stick up or down after inputting the C-Stick horizontally.
 
 ## Grab
 


### PR DESCRIPTION
Completely overhauls Shielding to be more of a punishment for not Parrying/Dodging.

Changelog:
- Removes traditional Out of Shield. Attempting to perform an action that isn't Roll, Spotdodge, will forcefully drop your shield first, then buffer the input.
  - Grabs will not force Shield Drop first if they are performed during the first few frames of putting up Shield.
- Removed the old custom shield release attack cancel implementation.
- Shield Release frames: 11 > 5
- Shield Release Disable Shield Frames: 0 > 6
  - This value gets added to Shield Release frames to get the total amount of frames you cannot Shield at all after starting a Shield Release. For example, if you release Shield and Dash on the first possible frame (frame 6), Shield will *stay disabled* for another 6 frames.