### PR TITLE
Make Air Dash its own Status

### DIFF
--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -58,7 +58,7 @@ pub mod fighter {
             // pub const IS_FGC : i32 = 0x0005;
             pub const CANCEL_ESCAPE_TO_ESCAPE_FB : i32 = 0x0006;
             pub const SUPER_JUMP : i32 = 0x0007;
-            pub const FORCE_ESCAPE_AIR_SLIDE : i32 = 0x0008;
+            // pub const FORCE_ESCAPE_AIR_SLIDE : i32 = 0x0008;
             pub const LEDGE_INTANGIBILITY : i32 = 0x0009;
         }
         pub mod int {
@@ -88,6 +88,7 @@ pub mod fighter {
             pub const ENABLE_AERIAL_STRING : i32 = 0x1004;
             pub const IS_DASH_CANCEL : i32 = 0x1005;
             pub const SKIP_IS_STATUS_CLIFF_CHECK : i32 = 0x1006;
+            pub const FORCE_ESCAPE_AIR_SLIDE_IN_STATUS : i32 = 0x1007;
         }
         pub mod int {
             pub const ENABLED_AERIALS : i32 = 0x1000;

--- a/WuBor-Utils/src/wua_bind.rs
+++ b/WuBor-Utils/src/wua_bind.rs
@@ -121,8 +121,8 @@ pub mod FGCModule {
         || (on_block && AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_SHIELD)))
         && check_cancel_window(fighter))
         || whiff {
+            VarModule::on_flag(fighter.battle_object, fighter::status::flag::FORCE_ESCAPE_AIR_SLIDE_IN_STATUS);
             if airdash_cancel_common(fighter, sit.into()).get_bool() {
-                VarModule::on_flag(fighter.battle_object, fighter::instance::flag::FORCE_ESCAPE_AIR_SLIDE);
                 return true.into();
             }
         }

--- a/custom-cancel/src/lib.rs
+++ b/custom-cancel/src/lib.rs
@@ -761,10 +761,11 @@ impl CustomCancelManager {
                     cancel_window
                 };
                 
-                if condition && flag_check
-                && airdash_cancel_common(fighter, situation.into()).get_bool() {
-                    VarModule::on_flag(fighter.battle_object, fighter::instance::flag::FORCE_ESCAPE_AIR_SLIDE);
-                    return true;
+                if condition && flag_check {
+                    VarModule::on_flag(fighter.battle_object, fighter::status::flag::FORCE_ESCAPE_AIR_SLIDE_IN_STATUS);
+                    if airdash_cancel_common(fighter, situation.into()).get_bool() {
+                        return true;
+                    }
                 }
 
                 if let Some(exception_func) = cancel_info.exception {

--- a/src/fighter/common/status.rs
+++ b/src/fighter/common/status.rs
@@ -11,6 +11,7 @@ mod guard_off;
 mod guard_damage;
 mod escape;
 mod escape_air;
+pub mod escape_air_slide;
 mod passive;
 pub mod attack;
 mod attack_100;
@@ -49,6 +50,7 @@ pub fn install() {
     guard_damage::install();
     escape::install();
     escape_air::install();
+    escape_air_slide::install();
     passive::install();
     attack::install();
     attack_100::install();

--- a/src/fighter/common/status/escape.rs
+++ b/src/fighter/common/status/escape.rs
@@ -1,7 +1,14 @@
 use crate::imports::status_imports::*;
+use smash_rs::app::work_ids;
+
+#[skyline::hook(replace = L2CFighterCommon_sub_escape_uniq_process_initStatus)]
+unsafe fn sub_escape_uniq_process_initstatus(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.sub_escape_uniq_process_common_initStatus();
+    0.into()
+}
 
 #[skyline::hook(replace = L2CFighterCommon_sub_escape_uniq_process_common_initStatus_common)]
-unsafe fn sub_escape_uniq_process_common_initstatus_common(fighter: &mut L2CFighterCommon, param_1: L2CValue, param_2: L2CValue) {
+unsafe fn sub_escape_uniq_process_common_initstatus_common(fighter: &mut L2CFighterCommon, _param_1: L2CValue, _param_2: L2CValue) {
     if fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() != *FIGHTER_STATUS_KIND_ESCAPE_AIR {
         sv_kinetic_energy!(
             clear_speed_ex,
@@ -11,14 +18,6 @@ unsafe fn sub_escape_uniq_process_common_initstatus_common(fighter: &mut L2CFigh
     }
     else {
         let prev_status = fighter.global_table[PREV_STATUS_KIND].get_i32();
-        let stick_x = param_1.get_f32();
-        let stick_y = param_2.get_f32();
-        let length = sv_math::vec2_length(stick_x, stick_y);
-        let escape_air_slide_stick = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("escape_air_slide_stick"));
-        if escape_air_slide_stick <= length
-        || VarModule::is_flag(fighter.battle_object, fighter::instance::flag::FORCE_ESCAPE_AIR_SLIDE) {
-            WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE);
-        }
         if [
             *FIGHTER_STATUS_KIND_DAMAGE_FLY,
             *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
@@ -47,44 +46,39 @@ unsafe fn sub_escape_uniq_process_common_initstatus_common(fighter: &mut L2CFigh
         ].contains(&prev_status) {
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_PREV_STATUS_PASSIVE_GROUND);
         }
-        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE) {
-            WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_LANDING);
-        }
-        else {
-            WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_LANDING);
-            let escape_air_stiff_start_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_stiff_start_frame"));
-            WorkModule::set_float(fighter.module_accessor, escape_air_stiff_start_frame, *FIGHTER_STATUS_ESCAPE_AIR_STIFF_START_FRAME);
-            let escape_air_stiff_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_stiff_frame"));
-            WorkModule::set_float(fighter.module_accessor, escape_air_stiff_frame, *FIGHTER_STATUS_ESCAPE_AIR_STIFF_FRAME);
-            let some_bool = WorkModule::get_param_int(fighter.module_accessor, 0x2ea659cf56, 0) == 1;
-            if some_bool {
-                let mot = MotionModule::motion_kind(fighter.module_accessor);
-                if mot == hash40("jump_aerial_f") || mot == hash40("jump_aerial_b") {
-                    let some_float = WorkModule::get_param_float(fighter.module_accessor, 0x271984ee09, 0);
-                    let some_float2 = WorkModule::get_param_float(fighter.module_accessor, 0x2bf4bef265, 0);
-                    let frame = MotionModule::frame(fighter.module_accessor);
-                    let mut result = some_float - (some_float2 * frame);
-                    let air_speed_y_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_y_stable"), 0);
-                    if result < -air_speed_y_stable {
-                        result = -air_speed_y_stable;
-                    }
-                    sv_kinetic_energy!(
-                        reset_energy,
-                        fighter,
-                        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
-                        ENERGY_GRAVITY_RESET_TYPE_GRAVITY,
-                        0.0,
-                        result,
-                        0.0,
-                        0.0,
-                        0.0
-                    );
-                    sv_kinetic_energy!(
-                        enable,
-                        fighter,
-                        FIGHTER_KINETIC_ENERGY_ID_GRAVITY
-                    );
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_LANDING);
+        let escape_air_stiff_start_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_stiff_start_frame"));
+        WorkModule::set_float(fighter.module_accessor, escape_air_stiff_start_frame, *FIGHTER_STATUS_ESCAPE_AIR_STIFF_START_FRAME);
+        let escape_air_stiff_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_stiff_frame"));
+        WorkModule::set_float(fighter.module_accessor, escape_air_stiff_frame, *FIGHTER_STATUS_ESCAPE_AIR_STIFF_FRAME);
+        let some_bool = WorkModule::get_param_int(fighter.module_accessor, 0x2ea659cf56, 0) == 1;
+        if some_bool {
+            let mot = MotionModule::motion_kind(fighter.module_accessor);
+            if mot == hash40("jump_aerial_f") || mot == hash40("jump_aerial_b") {
+                let some_float = WorkModule::get_param_float(fighter.module_accessor, 0x271984ee09, 0);
+                let some_float2 = WorkModule::get_param_float(fighter.module_accessor, 0x2bf4bef265, 0);
+                let frame = MotionModule::frame(fighter.module_accessor);
+                let mut result = some_float - (some_float2 * frame);
+                let air_speed_y_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_y_stable"), 0);
+                if result < -air_speed_y_stable {
+                    result = -air_speed_y_stable;
                 }
+                sv_kinetic_energy!(
+                    reset_energy,
+                    fighter,
+                    FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+                    ENERGY_GRAVITY_RESET_TYPE_GRAVITY,
+                    0.0,
+                    result,
+                    0.0,
+                    0.0,
+                    0.0
+                );
+                sv_kinetic_energy!(
+                    enable,
+                    fighter,
+                    FIGHTER_KINETIC_ENERGY_ID_GRAVITY
+                );
             }
         }
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_ESCAPE_AIR);
@@ -99,27 +93,14 @@ unsafe fn sub_escape_uniq_process_common_initstatus_common(fighter: &mut L2CFigh
     if status_kind_interrupt == *FIGHTER_STATUS_KIND_ESCAPE_AIR {
         // used_escape = WorkModule::get_float(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLOAT_USED_ESCAPE_AIR);
         penalty_motion_rate = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("escape_air_penalty_motion_rate"));
-        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE) {
-            used_escape = 0.0; // new
-            hit_xlu_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_slide_hit_xlu_frame"));
-            penalty_hit_xlu_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_slide_penalty_hit_xlu_frame"));
-            hit_normal_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_slide_hit_normal_frame"));
-            penalty_hit_normal_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_slide_penalty_hit_normal_frame"));
-            if MotionModule::is_flag_start_1_frame_from_motion_kind(fighter.module_accessor, Hash40::new("escape_air_slide")) {
-                hit_xlu_frame -= 1.0;
-                penalty_hit_xlu_frame -= 1.0;
-            }
-        }
-        else {
-            used_escape = WorkModule::get_float(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLOAT_USED_ESCAPE_AIR); // new
-            hit_xlu_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_hit_xlu_frame"));
-            penalty_hit_xlu_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_penalty_hit_xlu_frame"));
-            hit_normal_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_hit_normal_frame"));
-            penalty_hit_normal_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_penalty_hit_normal_frame"));
-            if MotionModule::is_flag_start_1_frame_from_motion_kind(fighter.module_accessor, Hash40::new("escape_air")) {
-                hit_xlu_frame -= 1.0;
-                penalty_hit_xlu_frame -= 1.0;
-            }
+        used_escape = WorkModule::get_float(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLOAT_USED_ESCAPE_AIR); // new
+        hit_xlu_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_hit_xlu_frame"));
+        penalty_hit_xlu_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_penalty_hit_xlu_frame"));
+        hit_normal_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_hit_normal_frame"));
+        penalty_hit_normal_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("escape_air_penalty_hit_normal_frame"));
+        if MotionModule::is_flag_start_1_frame_from_motion_kind(fighter.module_accessor, Hash40::new("escape_air")) {
+            hit_xlu_frame -= 1.0;
+            penalty_hit_xlu_frame -= 1.0;
         }
     }
     if status_kind_interrupt == *FIGHTER_STATUS_KIND_ESCAPE_B {
@@ -192,8 +173,7 @@ unsafe fn sub_escape_uniq_process_common_initstatus_common(fighter: &mut L2CFigh
     }
     WorkModule::set_int(fighter.module_accessor, xlu_interp as i32, *FIGHTER_STATUS_ESCAPE_WORK_INT_HIT_XLU_FRAME);
     WorkModule::set_int(fighter.module_accessor, interp_invuln as i32, *FIGHTER_STATUS_ESCAPE_WORK_INT_HIT_NORMAL_FRAME);
-    if status_kind_interrupt == *FIGHTER_STATUS_KIND_ESCAPE_AIR
-    && !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE) {
+    if status_kind_interrupt == *FIGHTER_STATUS_KIND_ESCAPE_AIR {
         let add_xlu_start_frame = WorkModule::get_int(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_AIR_ESCAPE_ADD_XLU_START_FRAME);
         if 0 < add_xlu_start_frame {
             WorkModule::add_int(fighter.module_accessor, add_xlu_start_frame, *FIGHTER_STATUS_ESCAPE_WORK_INT_HIT_XLU_FRAME);
@@ -252,9 +232,49 @@ unsafe fn status_escape_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     0.into()
 }
 
+#[skyline::hook(offset = 0x645bc0)]
+unsafe fn handle_escape_staling(work: &mut smash_rs::app::WorkModule, status: i32) {
+    // This is actually completely vanilla, I just like having it here
+    if work.is_flag(work_ids::fighter::instance::DISABLE_ESCAPE_PENALTY) {
+        return;
+    }
+    if 0 < work.get_int(work_ids::fighter::instance::ESCAPE_PENALTY_FRAME) {
+        let escape_penalty_max_count = work.get_param_int(smash_rs::phx::Hash40::new("common"), smash_rs::phx::Hash40::new("escape_penalty_max_count")) as f32;
+        
+        let id_status_pair = [
+            (work_ids::fighter::instance::USED_ESCAPE, 0x1f),
+            (work_ids::fighter::instance::USED_ESCAPE_F, 0x20),
+            (work_ids::fighter::instance::USED_ESCAPE_B, 0x21),
+            (work_ids::fighter::instance::USED_ESCAPE_AIR, 0x22),
+        ];
+
+        for compare_status in id_status_pair.iter() {
+            let add_penalty = if status != compare_status.1 {
+                0.5
+            }
+            else {
+                1.0
+            };
+            let used_escape = work.get_float(compare_status.0);
+            let new_escape = if used_escape + add_penalty > escape_penalty_max_count {
+                escape_penalty_max_count
+            }
+            else {
+                used_escape + add_penalty
+            };
+            work.set_float(new_escape, compare_status.0);
+        }
+    }
+    let escape_penalty_frame = work.get_param_int(smash_rs::phx::Hash40::new("common"), smash_rs::phx::Hash40::new("escape_penalty_frame"));
+    work.set_int(escape_penalty_frame, work_ids::fighter::instance::ESCAPE_PENALTY_FRAME);
+    let escape_penalty_recovry_frame = work.get_param_int(smash_rs::phx::Hash40::new("common"), smash_rs::phx::Hash40::new("escape_penalty_recovry_frame"));
+    work.set_int(escape_penalty_recovry_frame, work_ids::fighter::instance::ESCAPE_RECOVERY_FRAME);
+}
+
 fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hooks!(
+            sub_escape_uniq_process_initstatus,
             sub_escape_uniq_process_common_initstatus_common,
             status_escape_main
         );
@@ -263,4 +283,7 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
 
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
+    skyline::install_hooks!(
+        handle_escape_staling
+    );
 }

--- a/src/fighter/common/status/escape_air.rs
+++ b/src/fighter/common/status/escape_air.rs
@@ -15,15 +15,12 @@ enum AirDashTier {
 pub unsafe fn setup_escape_air_slide_common(fighter: &mut L2CFighterCommon, param_1: L2CValue, param_2: L2CValue) {
     let mut stickx = param_1.get_f32();
     let mut sticky = param_2.get_f32();
-    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE) {
-        if VarModule::is_flag(fighter.battle_object, fighter::instance::flag::FORCE_ESCAPE_AIR_SLIDE) {
-            let length = sv_math::vec2_length(stickx, sticky);
-            let escape_air_slide_stick = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("escape_air_slide_stick"));
-            if length < escape_air_slide_stick {
-                stickx = 1.0 * PostureModule::lr(fighter.module_accessor);
-                sticky = 0.0;
-            }
-            VarModule::off_flag(fighter.battle_object, fighter::instance::flag::FORCE_ESCAPE_AIR_SLIDE);
+    if fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() == *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE {
+        let length = sv_math::vec2_length(stickx, sticky);
+        let escape_air_slide_stick = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("escape_air_slide_stick"));
+        if length < escape_air_slide_stick {
+            stickx = 1.0 * PostureModule::lr(fighter.module_accessor);
+            sticky = 0.0;
         }
         StatusModule::set_situation_kind(fighter.module_accessor, SituationKind(*SITUATION_KIND_AIR), true);
         let normalize = sv_math::vec2_normalize(stickx, sticky);
@@ -180,16 +177,9 @@ unsafe fn get_airdash_tier(fighter: &mut L2CFighterCommon) -> AirDashTier {
 #[skyline::hook(replace = L2CFighterCommon_status_EscapeAir)]
 unsafe fn status_escapeair(fighter: &mut L2CFighterCommon) -> L2CValue {
     fighter.sub_escape_air_common();
-    let is_slide = WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE);
-    let mot = if is_slide {
-        Hash40::new("escape_air_slide")
-    }
-    else {
-        Hash40::new("escape_air")
-    };
     MotionModule::change_motion(
         fighter.module_accessor,
-        mot,
+        Hash40::new("escape_air"),
         0.0,
         1.0,
         false,
@@ -197,17 +187,15 @@ unsafe fn status_escapeair(fighter: &mut L2CFighterCommon) -> L2CValue {
         false,
         false
     );
-    if !is_slide {
-        let rate_penalty = WorkModule::get_float(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_WORK_FLOAT_MOTION_RATE_PENALTY);
-        let add_xlu = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_ADD_XLU_START_FRAME);
-        if 0 < add_xlu {
-            let xlu = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_WORK_INT_HIT_XLU_FRAME);
-            let some = xlu - add_xlu;
-            let ratio = xlu as f32 / some as f32;
-            let inverse = 1.0 / ratio;
-            let rate = inverse * rate_penalty;
-            MotionModule::set_rate(fighter.module_accessor, rate);
-        }
+    let rate_penalty = WorkModule::get_float(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_WORK_FLOAT_MOTION_RATE_PENALTY);
+    let add_xlu = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_ADD_XLU_START_FRAME);
+    if 0 < add_xlu {
+        let xlu = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_WORK_INT_HIT_XLU_FRAME);
+        let some = xlu - add_xlu;
+        let ratio = xlu as f32 / some as f32;
+        let inverse = 1.0 / ratio;
+        let rate = inverse * rate_penalty;
+        MotionModule::set_rate(fighter.module_accessor, rate);
     }
     fighter.sub_shift_status_main(L2CValue::Ptr(L2CFighterCommon_bind_address_call_status_EscapeAir_Main as *const () as _))
 }
@@ -232,7 +220,7 @@ unsafe fn sub_escape_air_common_main(fighter: &mut L2CFighterCommon) -> L2CValue
             return true.into();
         }
     }
-    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE)
+    if fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() == *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE
     && !CancelModule::is_enable_cancel(fighter.module_accessor) {
         let airdash_params = get_airdash_params(fighter);
         if fighter.global_table[STATUS_FRAME].get_f32() >= airdash_params.attack_frame {
@@ -319,7 +307,7 @@ pub unsafe fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterCommon) 
 
     // // early return if airdashing
 
-    // if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE) {
+    // if fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() == *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE {
     //     return 0.into();
     // }
 
@@ -393,7 +381,7 @@ pub unsafe fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterCommon) 
 #[skyline::hook(replace = L2CFighterCommon_sub_escape_air_uniq)]
 pub unsafe fn sub_escape_air_uniq(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
     if !param_1.get_bool() {
-        let slide = WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE);
+        let slide = fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() == *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE;
         let escape_frame = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_WORK_INT_FRAME);
         let item_air_catch_frame_escape = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("item_air_catch_frame_escape"));
         if escape_frame <= item_air_catch_frame_escape {
@@ -407,10 +395,10 @@ pub unsafe fn sub_escape_air_uniq(fighter: &mut L2CFighterCommon, param_1: L2CVa
                 }
             }
         }
-        if fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() == *FIGHTER_STATUS_KIND_ESCAPE_AIR {
-            if slide {
-                fighter.exec_escape_air_slide();
-            }
+        if slide {
+            fighter.exec_escape_air_slide();
+        }
+        else {
             let xlu_start = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_ADD_XLU_START_FRAME);
             if 0 < xlu_start {
                 if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_FLAG_HIT_XLU) {
@@ -466,7 +454,7 @@ pub unsafe fn sub_escape_air_uniq(fighter: &mut L2CFighterCommon, param_1: L2CVa
         if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_KINE_FALL) {
             KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_FALL);
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_KINE_FALL);
-            if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE) {
+            if !fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() == *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE {
                 fighter.sub_fighter_cliff_check(L2CValue::Void());
             }
         }
@@ -729,43 +717,8 @@ unsafe fn status_end_escapeair(fighter: &mut L2CFighterCommon) -> L2CValue {
     let status = fighter.global_table[STATUS_KIND].get_i32();
     if status == *FIGHTER_STATUS_KIND_FALL
     || status == *FIGHTER_STATUS_KIND_LANDING {
-        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE) {
-            let landing_frame_escape_air_slide = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("landing_frame_escape_air_slide"));
-            let landing_frame_escape_air_slide_max = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("landing_frame_escape_air_slide_max"));
-            let frame = MotionModule::frame(fighter.module_accessor);
-            let end_frame = MotionModule::end_frame(fighter.module_accessor);
-            let frame_ratio = frame / end_frame;
-            let landing_frame = fighter.lerp(landing_frame_escape_air_slide.into(), landing_frame_escape_air_slide_max.into(), frame_ratio.into()).get_f32();
-            WorkModule::set_float(fighter.module_accessor, landing_frame, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
-            let escape_air_slide_landing_speed_max = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("escape_air_slide_landing_speed_max")) * 0.75;
-            fighter.clear_lua_stack();
-            lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_STOP);
-            let speed_x = sv_kinetic_energy::get_speed_x(fighter.lua_state_agent);
-            let landing_speed_mul_escape_air_slide = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("landing_speed_mul_escape_air_slide"));
-            let mut landing_speed = speed_x * landing_speed_mul_escape_air_slide;
-            fighter.clear_lua_stack();
-            lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_STOP);
-            let speed_y = sv_kinetic_energy::get_speed_y(fighter.lua_state_agent);
-            if escape_air_slide_landing_speed_max < landing_speed.abs() {
-                if landing_speed < 0.0 {
-                    landing_speed = -escape_air_slide_landing_speed_max;
-                }
-                else {
-                    landing_speed = escape_air_slide_landing_speed_max;
-                }
-            }
-            sv_kinetic_energy!(
-                set_speed,
-                fighter,
-                FIGHTER_KINETIC_ENERGY_ID_STOP,
-                landing_speed,
-                speed_y
-            );
-        }
-        else {
-            let landing_frame_escape_air = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("landing_frame_escape_air"));
-            WorkModule::set_float(fighter.module_accessor, landing_frame_escape_air as f32, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
-        }
+        let landing_frame_escape_air = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("landing_frame_escape_air"));
+        WorkModule::set_float(fighter.module_accessor, landing_frame_escape_air as f32, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
         if status == *FIGHTER_STATUS_KIND_LANDING {
             if !MotionModule::is_end(fighter.module_accessor) {
                 WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_TURN);
@@ -792,8 +745,6 @@ unsafe fn status_end_escapeair(fighter: &mut L2CFighterCommon) -> L2CValue {
             );
         }
     }
-    VarModule::off_flag(fighter.battle_object, fighter::instance::flag::FORCE_ESCAPE_AIR_SLIDE);
-    fighter.status_end_Jump();
     0.into()
 }
 

--- a/src/fighter/common/status/escape_air_slide.rs
+++ b/src/fighter/common/status/escape_air_slide.rs
@@ -1,0 +1,163 @@
+use crate::imports::status_imports::*;
+
+#[common_status_script( status = FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE )]
+unsafe fn escape_air_slide_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_AIR),
+        *FIGHTER_KINETIC_TYPE_MOTION_FALL,
+        *GROUND_CORRECT_KIND_AIR as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
+        false,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_ENABLE,
+        false,
+        false,
+        false,
+        0,
+        0,
+        0,
+        0
+    );
+    0.into()
+}
+
+#[common_status_script( status = FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS )]
+unsafe fn escape_air_slide_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let prev_status = fighter.global_table[PREV_STATUS_KIND].get_i32();
+    if [
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
+        *FIGHTER_STATUS_KIND_SAVING_DAMAGE_FLY
+    ].contains(&prev_status) {
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_PREV_STATUS_PASSIVE_GROUND);
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_PREV_STATUS_PASSIVE_AIR);
+        sv_kinetic_energy!(
+            controller_set_accel_x_mul,
+            fighter,
+            0.0
+        );
+        sv_kinetic_energy!(
+            controller_set_accel_x_add,
+            fighter,
+            0.0
+        );
+    }
+    if [
+        *FIGHTER_STATUS_KIND_DAMAGE_FALL,
+        *FIGHTER_STATUS_KIND_TREAD_FALL
+    ].contains(&prev_status) {
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_PREV_STATUS_PASSIVE_GROUND);
+    }
+    WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_LANDING);
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_ESCAPE_AIR);
+    FighterWorkModuleImpl::calc_escape_air_slide_param(fighter.module_accessor, 0.0);
+    fighter.setup_escape_air_slide();
+    0.into()
+}
+
+#[common_status_script( status = FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN )]
+unsafe fn escape_air_slide_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.sub_escape_air_common();
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("escape_air_slide"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+    fighter.sub_shift_status_main(L2CValue::Ptr(L2CFighterCommon_bind_address_call_status_EscapeAir_Main as *const () as _))
+}
+
+#[common_status_script( status = FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END )]
+unsafe fn escape_air_slide_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    escape_air_slide_end_inner(fighter)
+}
+
+pub unsafe fn escape_air_slide_end_inner(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let status = fighter.global_table[STATUS_KIND].get_i32();
+    if status == *FIGHTER_STATUS_KIND_FALL
+    || status == *FIGHTER_STATUS_KIND_LANDING {
+        let landing_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("landing_frame_escape_air_slide"));
+        WorkModule::set_float(fighter.module_accessor, landing_frame, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
+        let escape_air_slide_landing_speed_max = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("escape_air_slide_landing_speed_max")) * 0.75;
+        fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_STOP);
+        let speed_x = sv_kinetic_energy::get_speed_x(fighter.lua_state_agent);
+        let landing_speed_mul_escape_air_slide = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("landing_speed_mul_escape_air_slide"));
+        let mut landing_speed = speed_x * landing_speed_mul_escape_air_slide;
+        fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_STOP);
+        let speed_y = sv_kinetic_energy::get_speed_y(fighter.lua_state_agent);
+        if escape_air_slide_landing_speed_max < landing_speed.abs() {
+            if landing_speed < 0.0 {
+                landing_speed = -escape_air_slide_landing_speed_max;
+            }
+            else {
+                landing_speed = escape_air_slide_landing_speed_max;
+            }
+        }
+        sv_kinetic_energy!(
+            set_speed,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_STOP,
+            landing_speed,
+            speed_y
+        );
+        if status == *FIGHTER_STATUS_KIND_LANDING {
+            if !MotionModule::is_end(fighter.module_accessor) {
+                WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_TURN);
+            }
+            // WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_ENABLE_LANDING_CLIFF_STOP);
+        }
+    }
+    else {
+        fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_STOP);
+        let speed_x = sv_kinetic_energy::get_speed_x(fighter.lua_state_agent);
+        let mut air_speed_x_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_x_stable"), 0);
+        if speed_x.abs() > air_speed_x_stable {
+            air_speed_x_stable *= speed_x.signum();
+            fighter.clear_lua_stack();
+            lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_STOP);
+            let speed_y = sv_kinetic_energy::get_speed_y(fighter.lua_state_agent);
+            sv_kinetic_energy!(
+                set_speed,
+                fighter,
+                FIGHTER_KINETIC_ENERGY_ID_STOP,
+                air_speed_x_stable,
+                speed_y
+            );
+        }
+    }
+    0.into()
+}
+
+#[common_status_script( status = FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE, condition = LUA_SCRIPT_STATUS_FUNC_CALC_PARAM )]
+unsafe fn escape_air_slide_calc_param(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.FighterStatusUniqProcessEscapeAir_calc_param()
+}
+
+pub fn install() {
+    install_status_scripts!(
+        escape_air_slide_pre,
+        escape_air_slide_init,
+        escape_air_slide_main,
+        escape_air_slide_end,
+        escape_air_slide_calc_param
+    );
+}

--- a/src/fighter/common/status/escape_air_slide.rs
+++ b/src/fighter/common/status/escape_air_slide.rs
@@ -149,7 +149,8 @@ pub unsafe fn escape_air_slide_end_inner(fighter: &mut L2CFighterCommon) -> L2CV
 
 #[common_status_script( status = FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE, condition = LUA_SCRIPT_STATUS_FUNC_CALC_PARAM )]
 unsafe fn escape_air_slide_calc_param(fighter: &mut L2CFighterCommon) -> L2CValue {
-    fighter.FighterStatusUniqProcessEscapeAir_calc_param()
+    FighterWorkModuleImpl::calc_escape_air_slide_param(fighter.module_accessor, 0.0);
+    0.into()
 }
 
 pub fn install() {

--- a/src/fighter/common/status/landing.rs
+++ b/src/fighter/common/status/landing.rs
@@ -30,7 +30,7 @@ unsafe fn status_pre_landing_param(fighter: &mut L2CFighterCommon, param_1: L2CV
 }
 
 #[skyline::hook(replace = L2CFighterCommon_status_pre_LandingLight_param)]
-unsafe fn status_pre_landinglight_param(fighter: &mut L2CFighterCommon, param_1: L2CValue,  param_2: L2CValue,  param_3: L2CValue,  param_4: L2CValue,  param_5: L2CValue) -> L2CValue {
+unsafe fn status_pre_landinglight_param(fighter: &mut L2CFighterCommon, param_1: L2CValue, param_2: L2CValue, param_3: L2CValue, param_4: L2CValue, param_5: L2CValue) -> L2CValue {
     StatusModule::init_settings(
         fighter.module_accessor,
         SituationKind(*SITUATION_KIND_GROUND),
@@ -59,7 +59,7 @@ unsafe fn status_pre_landinglight_param(fighter: &mut L2CFighterCommon, param_1:
 }
 
 #[skyline::hook(replace = L2CFighterCommon_status_pre_landing_fall_special_common)]
-unsafe fn status_pre_landing_fall_special_common(fighter: &mut L2CFighterCommon, param_1: L2CValue,  param_2: L2CValue,  param_3: L2CValue) -> L2CValue {
+unsafe fn status_pre_landing_fall_special_common(fighter: &mut L2CFighterCommon, param_1: L2CValue, param_2: L2CValue, param_3: L2CValue) -> L2CValue {
     StatusModule::init_settings(
         fighter.module_accessor,
         SituationKind(*SITUATION_KIND_GROUND),
@@ -87,12 +87,137 @@ unsafe fn status_pre_landing_fall_special_common(fighter: &mut L2CFighterCommon,
     0.into()
 }
 
+#[skyline::hook(replace = L2CFighterCommon_sub_landing_uniq_process_init_main_param)]
+unsafe fn sub_landing_uniq_process_init_main_param(fighter: &mut L2CFighterCommon, param_1: L2CValue, param_2: L2CValue, param_3: L2CValue, param_4: L2CValue) {
+    let landing_mot = param_3.get_u64();
+    let status_interrupt = fighter.global_table[STATUS_KIND_INTERRUPT].get_i32();
+    if status_interrupt != param_2.get_i32()
+    && status_interrupt != *FIGHTER_STATUS_KIND_LANDING_DAMAGE_LIGHT {
+        if status_interrupt != param_4.get_i32() {
+            if status_interrupt == *FIGHTER_STATUS_KIND_LANDING_ATTACK_AIR {
+                let aerial_mot = WorkModule::get_int64(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_AIR_WORK_INT_MOTION_KIND);
+                let landing_lag_param;
+                let landing_mot;
+                let kind;
+                if aerial_mot == hash40("attack_air_n") {
+                    landing_lag_param = hash40("landing_attack_air_frame_n");
+                    landing_mot = hash40("landing_air_n");
+                    kind = FIGHTER_LOG_ATTACK_KIND_ATTACK_AIR_N;
+                }
+                else if aerial_mot == hash40("attack_air_f") {
+                    landing_lag_param = hash40("landing_attack_air_frame_f");
+                    landing_mot = hash40("landing_air_f");
+                    kind = FIGHTER_LOG_ATTACK_KIND_ATTACK_AIR_F;
+                }
+                else if aerial_mot == hash40("attack_air_b") {
+                    landing_lag_param = hash40("landing_attack_air_frame_b");
+                    landing_mot = hash40("landing_air_b");
+                    kind = FIGHTER_LOG_ATTACK_KIND_ATTACK_AIR_B;
+                }
+                else if aerial_mot == hash40("attack_air_hi") {
+                    landing_lag_param = hash40("landing_attack_air_frame_hi");
+                    landing_mot = hash40("landing_air_hi");
+                    kind = FIGHTER_LOG_ATTACK_KIND_ATTACK_AIR_HI;
+                }
+                else {
+                    landing_lag_param = hash40("landing_attack_air_frame_lw");
+                    landing_mot = hash40("landing_air_lw");
+                    kind = FIGHTER_LOG_ATTACK_KIND_ATTACK_AIR_LW;
+                }
+                notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2b94de0d96), FIGHTER_LOG_ACTION_CATEGORY_ATTACK, kind);
+                fighter.sub_landing_attack_air_init(landing_mot.into(), landing_lag_param.into(), 0.into());
+            }
+            if status_interrupt == *FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL {
+                fighter.sub_landing_fall_special_init(param_1);
+            }
+        }
+    }
+    else {
+        if status_interrupt == *FIGHTER_STATUS_KIND_LANDING_DAMAGE_LIGHT {
+            effect!(fighter, MA_MSC_EFFECT_SET_DISABLE_LANDING_EFFECT, true);
+        }
+        let mut rate = 1.0;
+        let prev_status = fighter.global_table[PREV_STATUS_KIND].get_i32();
+        if [*FIGHTER_STATUS_KIND_ESCAPE_AIR, *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE].contains(&prev_status) {
+            let mot = MotionModule::motion_kind(fighter.module_accessor);
+            if mot == hash40("escape_air_slide")
+            || {
+                let cancel_frame = FighterMotionModuleImpl::get_cancel_frame(fighter.module_accessor, Hash40::new("invalid"), true);
+                cancel_frame <= 0.0
+            }
+            || !FighterMotionModuleImpl::is_valid_cancel_frame(fighter.module_accessor, -1, true) {
+                let landing_frame = WorkModule::get_float(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
+                if landing_frame != 0.0 {
+                    let end_frame = MotionModule::end_frame_from_hash(fighter.module_accessor, Hash40::new_raw(landing_mot));
+                    rate = fighter.sub_calc_landing_motion_rate(end_frame.into(), landing_frame.into()).get_f32();
+                    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_CANCEL);
+                }
+            }
+        }
+        if [*FIGHTER_STATUS_KIND_DAMAGE_AIR, *FIGHTER_STATUS_KIND_SAVING_DAMAGE_AIR].contains(&prev_status) {
+            let landing_frame = WorkModule::get_float(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLOAT_DAMAGE_REACTION_FRAME);
+            let end_frame = MotionModule::end_frame_from_hash(fighter.module_accessor, Hash40::new_raw(landing_mot));
+            if end_frame < landing_frame {
+                rate = fighter.sub_calc_landing_motion_rate(end_frame.into(), landing_frame.into()).get_f32();
+            }
+        }
+        MotionModule::change_motion(
+            fighter.module_accessor,
+            Hash40::new_raw(landing_mot),
+            0.0,
+            rate,
+            false,
+            0.0,
+            false,
+            false
+        );
+    }
+    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_RUN_FALL) {
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_RUN_FALL);
+        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_RUN_FALL);
+    }
+
+    // Landing Turn stuff which is now gone
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_TURN);
+
+    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_ENABLE_LANDING_CLIFF_STOP) {
+        GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND_CLIFF_STOP));
+        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_ENABLE_LANDING_CLIFF_STOP);
+    }
+}
+
+#[skyline::hook(replace = L2CFighterCommon_status_LandingSub)]
+unsafe fn status_landingsub(fighter: &mut L2CFighterCommon) {
+    if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_HAMMER)
+    && !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_GENESISSET)
+    && ItemModule::get_have_item_kind(fighter.module_accessor, 0) != *ITEM_KIND_ASSIST {
+        fighter.sub_landing_ground_check_common_pre();
+        if !StopModule::is_stop(fighter.module_accessor) {
+            fighter.sub_landing_uniq_check();
+        }
+        fighter.global_table[SUB_STATUS2].assign(&L2CValue::Ptr(L2CFighterCommon_bind_address_call_sub_landing_uniq_check as *const () as _));
+    }
+    if [*FIGHTER_STATUS_KIND_ESCAPE_AIR, *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE].contains(&fighter.global_table[PREV_STATUS_KIND].get_i32()) {
+        let stick_y = ControlModule::get_stick_y(fighter.module_accessor).abs();
+        let stick_x = ControlModule::get_stick_x(fighter.module_accessor).abs();
+        if stick_y < 0.00001 {
+            ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_ESCAPE);
+        }
+        if stick_x < 0.00001 {
+            ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_ESCAPE_F);
+            ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_ESCAPE_B);
+        }
+    }
+}
+
 fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hooks!(
             status_pre_landing_param,
             status_pre_landinglight_param,
-            status_pre_landing_fall_special_common
+            status_pre_landing_fall_special_common,
+            sub_landing_uniq_process_init_main_param,
+            status_landingsub
         );
     }
 }

--- a/src/fighter/common/status/sub_set_status.rs
+++ b/src/fighter/common/status/sub_set_status.rs
@@ -1,0 +1,32 @@
+use crate::imports::status_imports::*;
+
+#[skyline::hook(replace = L2CFighterCommon_sub_set_status_pre_msc_common_table)]
+unsafe fn sub_set_status_pre_msc_common_table(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        if fighter.global_table[CHECK_GROUND_JUMP_MINI_ATTACK].get_bool() {
+            let callable: extern "C" fn(&mut L2CFighterCommon) -> L2CValue = std::mem::transmute(fighter.global_table[CHECK_GROUND_JUMP_MINI_ATTACK].get_ptr());
+            return callable(fighter);
+        }
+        // Disable the grab button from being used to perform the "short hop aerial macro"
+        let cat1 = fighter.global_table[CMD_CAT1].get_i32();
+        if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH == 0
+        && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N != 0
+        && fighter.sub_check_button_jump().get_bool() {
+            fighter.change_status_jump_mini_attack(false.into());
+            return true.into();
+        }
+    }
+    false.into()
+}
+
+fn nro_hook(info: &skyline::nro::NroInfo) {
+    if info.name == "common" {
+        skyline::install_hooks!(
+            sub_set_status_pre_msc_common_table
+        );
+    }
+}
+
+pub fn install() {
+    skyline::nro::add_hook(nro_hook);
+}

--- a/src/fighter/edge/status/helper.rs
+++ b/src/fighter/edge/status/helper.rs
@@ -75,6 +75,7 @@ pub unsafe extern "C" fn edge_special_hi_param_helper_inner(hash: L2CValue, char
 pub unsafe extern "C" fn edge_special_hi_cancel(fighter: &mut L2CFighterCommon) -> L2CValue {
     if VarModule::is_flag(fighter.battle_object, edge::status::flag::SPECIAL_HI_CANCEL)
     && VarModule::get_int(fighter.battle_object, edge::instance::int::SPECIAL_HI_CANCEL_COUNT) < 2 {
+        VarModule::on_flag(fighter.battle_object, fighter::status::flag::FORCE_ESCAPE_AIR_SLIDE_IN_STATUS);
         let cat1 = fighter.global_table[CMD_CAT1].get_i32();
         if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0 {
             VarModule::inc_int(fighter.battle_object, edge::instance::int::SPECIAL_HI_CANCEL_COUNT);
@@ -92,7 +93,6 @@ pub unsafe extern "C" fn edge_special_hi_cancel(fighter: &mut L2CFighterCommon) 
         }
         WorkModule::enable_transition_term_group(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_GROUP_CHK_AIR_ESCAPE);
         if fighter.sub_transition_group_check_air_escape().get_bool() {
-            VarModule::on_flag(fighter.battle_object, fighter::instance::flag::FORCE_ESCAPE_AIR_SLIDE);
             return true.into();
         }
     }

--- a/src/fighter/lucario/status.rs
+++ b/src/fighter/lucario/status.rs
@@ -4,6 +4,7 @@ mod special_s;
 mod special_hi;
 mod special_lw;
 mod escape_air;
+mod escape_air_slide;
 mod landing;
 
 pub fn install() {
@@ -13,5 +14,6 @@ pub fn install() {
     special_hi::install();
     special_lw::install();
     escape_air::install();
+    escape_air_slide::install();
     landing::install();
 }

--- a/src/fighter/lucario/status/escape_air_slide.rs
+++ b/src/fighter/lucario/status/escape_air_slide.rs
@@ -1,0 +1,18 @@
+use crate::imports::status_imports::*;
+use crate::fighter::common::status::escape_air_slide::*;
+
+#[status_script(agent = "lucario", status = FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
+unsafe fn lucario_escape_air_slide_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let landing_frame = WorkModule::get_float(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
+    escape_air_slide_end_inner(fighter);
+    if VarModule::is_flag(fighter.battle_object, lucario::instance::flag::FORCE_LANDING_FALL_SPECIAL) {
+        WorkModule::set_float(fighter.module_accessor, landing_frame, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
+    }
+    0.into()
+}
+
+pub fn install() {
+    install_status_scripts!(
+        lucario_escape_air_slide_end
+    );
+}


### PR DESCRIPTION
Directional Air Dodge actually has its own status that goes unused in vanilla, so here I am now making use of it.

Changelog:
- Makes Air Dash its own Status.
  - This means that Air Dash is now exempt from Dodge Staling, so Air Dashing will no longer affect your normal dodges.
- That's it actually.