### PR TITLE
Mega Man Hotfixes

### DIFF
--- a/src/fighter/rockman/acmd/aerials.rs
+++ b/src/fighter/rockman/acmd/aerials.rs
@@ -160,6 +160,7 @@ unsafe fn rockman_attackairb(fighter: &mut L2CAgentBase) {
 unsafe fn game_regular(weapon: &mut L2CAgentBase) {
     if macros::is_excute(weapon) {
         macros::ATTACK(weapon, 0, 0, Hash40::new("top"), 0.75, 367, 100, 70, 0, 5.0, 0.0, 3.0, 0.0, None, None, None, 0.2, 0.7, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 3, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_NONE);
+        macros::ATK_SET_SHIELD_SETOFF_MUL(weapon, 0, 0.5);
     }
     frame(weapon.lua_state_agent, 20.0);
     if macros::is_excute(weapon) {
@@ -168,6 +169,7 @@ unsafe fn game_regular(weapon: &mut L2CAgentBase) {
     frame(weapon.lua_state_agent, 30.0);
     if macros::is_excute(weapon) {
         macros::ATTACK(weapon, 0, 0, Hash40::new("top"), 4.0, 92, 50, 0, 90, 7.0, 0.0, 3.0, 0.0, None, None, None, 0.2, 0.7, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_NONE);
+        macros::ATK_SET_SHIELD_SETOFF_MUL(weapon, 0, 0.5);
         WorkModule::on_flag(weapon.module_accessor, *WEAPON_ROCKMAN_AIRSHOOTER_INSTANCE_WORK_ID_FLAG_ATTACK_VECTOR_REVERSE_UD_CHECK);
     }
 }

--- a/src/fighter/rockman/vtable_hook.rs
+++ b/src/fighter/rockman/vtable_hook.rs
@@ -280,6 +280,9 @@ pub fn install() {
     skyline::patching::Patch::in_text(0x10839b8).nop();
     skyline::patching::Patch::in_text(0x10839cc).nop();
 
+    // Patches which status to compare to for Metal Blade.
+    skyline::patching::Patch::in_text(0x1080264).data(0x7107741F);
+
     skyline::install_hooks!(
         rockman_vtable_func,
         rockman_do_leafshield_things_disable,

--- a/wubor-changelog/src/characters/smash4/rockman.md
+++ b/wubor-changelog/src/characters/smash4/rockman.md
@@ -167,10 +167,10 @@ Acceleration: 0.07 > 0.1
 
 <datatable>
 
-| Hitbox Duration | Damage | Angle | Base Knockback | Knockback Growth | Rehit Rate |
-|:--------------- |:------ |:----- |:-------------- |:---------------- |:---------- |
-| 1 - 29          | 0.75   | 367   | N/A            | N/A              | 3          |
-| 30+             | 4      | 92    | 90             | 50               | 0          |
+| Hitbox Duration | Damage | Angle | Base Knockback | Knockback Growth | Rehit Rate | Blockstun Multiplier |
+|:--------------- |:------ |:----- |:-------------- |:---------------- |:---------- |:-------------------- |
+| 1 - 29          | 0.75   | 367   | N/A            | N/A              | 3          | 0.5x                 |
+| 30+             | 4      | 92    | 90             | 50               | 0          | 0.5x                 |
 
 </datatable>
 


### PR DESCRIPTION
Fixes a bug where Metal Blade wouldn't despawn if Mega Man gets hit before throwing it.

Cuts Air Shooter's blockstun in half.