### PR TITLE
DI Line go Bye Bye

### DIFF
--- a/src/fighter/common/status/damage.rs
+++ b/src/fighter/common/status/damage.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use crate::imports::status_imports::*;
 use super::super::param;
 
@@ -166,7 +168,7 @@ unsafe fn init_damage_speed_up_inner(fighter: &mut L2CFighterCommon, angle: f32,
     fighter.lerp((1.0).into(), (angle_rate * 0.01).into(), ratio.into()).get_f32()
 }
 
-#[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_FighterStatusUniqProcessDamage_leave_stop)]
+#[skyline::hook(replace = L2CFighterCommon_FighterStatusUniqProcessDamage_leave_stop)]
 unsafe fn fighterstatusuniqprocessdamage_leave_stop(fighter: &mut L2CFighterCommon, arg2: L2CValue, arg3: L2CValue) -> L2CValue {
     // <WuBor>
     ShakeModule::stop(fighter.module_accessor);
@@ -174,12 +176,18 @@ unsafe fn fighterstatusuniqprocessdamage_leave_stop(fighter: &mut L2CFighterComm
     original!()(fighter, arg2, arg3)
 }
 
+#[skyline::hook(replace = L2CFighterCommon_FighterStatusDamage__requestVectorAdjustEffect)]
+unsafe fn fighterstatusdamage__requestvectoradjusteffect(_fighter: &mut L2CFighterCommon, _arg1: L2CValue, _arg2: L2CValue, _arg3: L2CValue, _arg4: L2CValue, _arg5: L2CValue, _arg6: L2CValue,) {
+    // nothing lmao
+}
+
 fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hooks!(
             status_pre_damage,
             ftstatusuniqprocessdamage_init_common,
-            fighterstatusuniqprocessdamage_leave_stop
+            fighterstatusuniqprocessdamage_leave_stop,
+            fighterstatusdamage__requestvectoradjusteffect
         );
     }
 }

--- a/wubor-changelog/src/system/engine.md
+++ b/wubor-changelog/src/system/engine.md
@@ -73,14 +73,18 @@ It is now possible to slip off of ledges during the following states:
 * Special Fall/Freefall Landing
 * Taunt
 
-## Geting Launched
+## Knockback
 
 * The spinning knockback animation no longer is randomly applied, instead being applied at a consistent `character weight + 33` damage threshold, meant to signify average kill percent.
 * Balloon Knockback has been reworked.
   * Balloon Knockback now applies based on Launch Speed instead of total Hitstun frames.
   * Maximum Balloon Knockback magitude has been reduced (6 > 4), making it have less of, but still a noticable effect.
+
+## Directional Influence
+
 * Directional Influence has been increased (9.74 degrees / 0.17 radians > 12.0321 degrees / 0.21 radians).
 * Launch Speed Influence has been removed.
+* The DI Guide Line has been removed.
 
 ## Teching
 


### PR DESCRIPTION
While the DI Line was no doubt helpful to follow the opponent's trajectory, I always thought it was too small to see in normal gameplay to matter.
In addition, removing the DI line buffs defense a little bit, making DI something the opponent has to guess on again.

May not get merged.