### PR TITLE
Parry Updates

### DIFF
--- a/custom-var/src/lib.rs
+++ b/custom-var/src/lib.rs
@@ -164,8 +164,8 @@ impl VarModule {
         varmodule.reset_status_pairs.insert(0x3, vec![-1, 0x3, 0x7]); // Not Dashes into Dash
         varmodule.reset_status_pairs.insert(0x7, vec![-1, 0x3, 0x7]); // Not Dashes into Turn Dash
         varmodule.reset_status_pairs.insert(0x18, vec![0x36]); // Aerial into Landing
-        varmodule.reset_status_pairs.insert(0x1E, vec![0x1B, 0x1C]); // Guards into Guard Damage
-        varmodule.reset_status_pairs.insert(0x1C, vec![0x1B, 0x1E]); // Guards into Guard Damage
+        varmodule.reset_status_pairs.insert(0x1E, vec![0x1B, 0x1C, 0x1E]); // Guards into Guard Damage
+        varmodule.reset_status_pairs.insert(0x1C, vec![0x1B, 0x1C, 0x1E]); // Guards into Guard
         varmodule.reset_status_pairs.insert(0x1D, vec![0x1B, 0x1C, 0x1E]); // Guards into Guard Off
         varmodule
     }
@@ -562,7 +562,7 @@ impl VarModule {
     #[export_name = "VarModule__countdown_int"]
     pub extern "Rust" fn countdown_int(object: *mut BattleObject, what: i32, min: i32) -> bool {
         if Self::get_int(object, what) < min {
-            true
+            false
         } else {
             Self::dec_int(object, what);
             Self::get_int(object, what) < min

--- a/src/fighter/common/status/guard/guard_damage.rs
+++ b/src/fighter/common/status/guard/guard_damage.rs
@@ -368,6 +368,9 @@ unsafe fn sub_guarddamageuniq(fighter: &mut L2CFighterCommon, param_1: L2CValue)
         }
     }
     if WorkModule::count_down_int(fighter.module_accessor, *FIGHTER_STATUS_GUARD_DAMAGE_WORK_INT_STIFF_FRAME, 0) == 0 {
+        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_JUST_SHIELD) {
+            CancelModule::enable_cancel(fighter.module_accessor);
+        }
         return 0.into();
     }
     if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_JUST_SHIELD) {
@@ -377,10 +380,10 @@ unsafe fn sub_guarddamageuniq(fighter: &mut L2CFighterCommon, param_1: L2CValue)
             }
             WorkModule::off_flag(fighter.module_accessor, *FIGHTER_STATUS_GUARD_DAMAGE_WORK_FLAG_GOLD_EYE);
         }
-        // if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_HIT_XLU) {
-        //     HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_NORMAL), 0);
-        //     WorkModule::off_flag(fighter.module_accessor, *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_HIT_XLU);
-        // }
+        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_HIT_XLU) {
+            HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_NORMAL), 0);
+            WorkModule::off_flag(fighter.module_accessor, *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_HIT_XLU);
+        }
         EffectModule::req_on_joint(
             fighter.module_accessor,
             Hash40::new("sys_windwave"),
@@ -419,10 +422,6 @@ unsafe fn status_guarddamage_main(fighter: &mut L2CFighterCommon) -> L2CValue {
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_ENABLE_TRANSITION_STATUS_STOP);
         }
         if CancelModule::is_enable_cancel(fighter.module_accessor) {
-            if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_HIT_XLU) {
-                HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_NORMAL), 0);
-                WorkModule::off_flag(fighter.module_accessor, *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_HIT_XLU);
-            }
             if fighter.sub_wait_ground_check_common(false.into()).get_bool()
             && is_hit {
                 StopModule::cancel_hit_stop(fighter.module_accessor);

--- a/src/fighter/common/status/guard/guard_on.rs
+++ b/src/fighter/common/status/guard/guard_on.rs
@@ -5,10 +5,21 @@ unsafe fn sub_ftstatusuniqprocessguardon_initstatus_common(fighter: &mut L2CFigh
     // Original
     ShieldModule::set_status(fighter.module_accessor, *FIGHTER_SHIELD_KIND_GUARD, ShieldStatus(*SHIELD_STATUS_NORMAL), 0);
     // Additions
-    if FighterUtil::is_valid_just_shield(fighter.module_accessor) {
+    let was_parry = fighter.global_table[PREV_STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_GUARD_DAMAGE;
+    if FighterUtil::is_valid_just_shield(fighter.module_accessor)
+    && (
+        ControlModule::get_trigger_count(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD as u8) <= 5
+        || was_parry
+    ) {
         let shield_just_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("shield_just_frame")) as f32;
         let just_shield_check_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("just_shield_check_frame"), 0);
-        let just_frame = (shield_just_frame * just_shield_check_frame + 0.5) as i32;
+        let just_frame_add = if was_parry {
+            3.0
+        }
+        else {
+            0.0
+        };
+        let just_frame = (shield_just_frame * just_shield_check_frame + 0.5 + just_frame_add) as i32;
         WorkModule::set_int(fighter.module_accessor, just_frame, *FIGHTER_STATUS_GUARD_ON_WORK_INT_JUST_FRAME);
         ShieldModule::set_shield_type(fighter.module_accessor, ShieldType(*SHIELD_TYPE_JUST_SHIELD), *FIGHTER_SHIELD_KIND_GUARD, 0);
         if FighterUtil::is_valid_just_shield_reflector(fighter.module_accessor) {

--- a/wubor-changelog/src/system/engine.md
+++ b/wubor-changelog/src/system/engine.md
@@ -56,7 +56,7 @@ Out-of-Shield options have been significantly changed.
 * Parrying has been moved to Shield Startup instead of Shield Release.
 * The Parry window was reduced from 5 to 3 frames.
   * The Parry window is increased to 6 frames if Shield is held during a Parry.
-* Parries can only be buffered if the Shield button was pressed for less than 5 frames, otherwise you will only shield.
+* Parries can only be buffered if the Shield button was pressed for less than 5 frames, otherwise you will shield normally.
   * This ***does not*** apply if Shield is held during a parry.
 
 ## Grab

--- a/wubor-changelog/src/system/engine.md
+++ b/wubor-changelog/src/system/engine.md
@@ -27,9 +27,6 @@ Actions that put you into the normal falling animation will instead use the uniq
 ## Shield
 
 ### Shield Mechanics
-* Parrying has been moved to Shield Startup instead of Shield Release.
-* The Parry window was reduced from 5 to 3 frames.
-  * These two changes should make it possible, but difficult to parry multi-hit moves, as many slower multi-hits will require manual represses of Shield.
 * Shield Pushback was also increased by roughly 1.3x.
   * Shield Pushback while Parrying was reduced to 0.
 * Shield Release frames were reduced from 11 frames to 5.
@@ -44,7 +41,7 @@ Actions that put you into the normal falling animation will instead use the uniq
 ### Actions Into Shield
 * It is now possible to Shield during Dash and Back Dash (Ryu/Ken/Terry/Kazuya).
 
-## Actions Out of Shield
+### Actions Out of Shield
 Out-of-Shield options have been significantly changed.
 
 * It is now possible to perform a Platform Drop like in previous games.
@@ -54,6 +51,13 @@ Out-of-Shield options have been significantly changed.
   * In addition, Grab, Dash Grab, and Turn Grab can still be performed directly while putting up Shield. Performing Grab otherwise will force a Shield Drop first.
 * Using the C-Stick will drop shield and perform whatever the C-Stick is bound to.
   * Performing angled Tilts or Smash Attacks will require moving the left stick up or down after inputting the C-Stick horizontally.
+
+### Parries
+* Parrying has been moved to Shield Startup instead of Shield Release.
+* The Parry window was reduced from 5 to 3 frames.
+  * The Parry window is increased to 6 frames if Shield is held during a Parry.
+* Parries can only be buffered if the Shield button was pressed for less than 5 frames, otherwise you will only shield.
+  * This ***does not*** apply if Shield is held during a parry.
 
 ## Grab
 


### PR DESCRIPTION
# Changelog
## Shield
* Fixed a bug where if shielding a multihit move, the shield graphic would no longer reflect the current remaining shield health.
## Parries
* The Parry window is increased to 6 frames if Shield is held during a Parry.
* Parries can only be buffered if the Shield button was pressed for less than 5 frames, otherwise you will shield normally.
  * This ***does not*** apply if Shield is held during a parry.