### PR TITLE
Massive C Stick Overhaul + Others

### DIFF
--- a/WuBor-Utils/Cargo.toml
+++ b/WuBor-Utils/Cargo.toml
@@ -9,3 +9,5 @@ skyline_smash = { git = "https://github.com/blu-dev/skyline-smash.git", features
 smash_script = { git = "https://github.com/blu-dev/smash-script.git", branch = "development" }
 custom_var = { path = "../custom-var" }
 smash_singletons = { git = "https://github.com/WuBoytH/smash_singletons.git" }
+bitflags = "1.3.2"
+modular-bitfield = "0.11.2"

--- a/WuBor-Utils/src/controls.rs
+++ b/WuBor-Utils/src/controls.rs
@@ -1,0 +1,364 @@
+#![allow(non_snake_case, non_upper_case_globals, dead_code)]
+
+use {
+    bitflags::bitflags,
+    modular_bitfield::{bitfield, specifiers::*}
+};
+
+bitflags! {
+    pub struct Cat1: i32 {
+        const AttackN       = 0x1;
+        const AttackS3      = 0x2;
+        const AttackHi3     = 0x4;
+        const AttackLw3     = 0x8;
+        const AttackS4      = 0x10;
+        const AttackHi4     = 0x20;
+        const AttackLw4     = 0x40;
+        const AttackAirN    = 0x80;
+        const AttackAirF    = 0x100;
+        const AttackAirB    = 0x200;
+        const AttackAirHi   = 0x400;
+        const AttackAirLw   = 0x800;
+        const SpecialN      = 0x1000;
+        const SpecialS      = 0x2000;
+        const SpecialHi     = 0x4000;
+        const SpecialLw     = 0x8000;
+        const SpecialAny    = 0xF000;
+        const Walk          = 0x10000;
+        const Dash          = 0x20000;
+        const Turn          = 0x40000;
+        const TurnDash      = 0x80000;
+        const Jump          = 0x100000;
+        const JumpButton    = 0x200000;
+        const AirEscape     = 0x400000;
+        const Squat         = 0x800000;
+        const Escape        = 0x1000000;
+        const EscapeF       = 0x2000000;
+        const EscapeB       = 0x4000000;
+        const WallJumpLeft  = 0x8000000;
+        const WallJumpRight = 0x10000000;
+        const Catch         = 0x20000000;
+        const NoCmd         = 0x40000000;
+    }
+
+    pub struct Cat2: i32 {
+        const AppealSL            = 0x1;
+        const AppealSR            = 0x2;
+        const AppealHi            = 0x4;
+        const AppealLw            = 0x8;
+        const AppealSmash         = 0x10;
+        const AppealAll           = 0x1F;
+        const AttackDashAttackHi4 = 0x20;
+        const FallJump            = 0x40;
+        const DashAttackS4        = 0x80;
+        const DamageFallToFall    = 0x100;
+        const DownToDownStandFB   = 0x200;
+        const DownToDownStand     = 0x400;
+        const GuardToPass         = 0x800;
+        const SquatToSquatF       = 0x1000;
+        const SquatToSquatB       = 0x2000;
+        const TurnToEscapeF       = 0x4000;
+        const TurnToEscapeB       = 0x8000;
+        const StickEscapeF        = 0x10000;
+        const StickEscapeB        = 0x20000;
+        const StickEscape         = 0x40000;
+        const SpecialNReverseLR   = 0x80000;
+        const ThrowF              = 0x100000;
+        const ThrowB              = 0x200000;
+        const ThrowHi             = 0x400000;
+        const ThrowLw             = 0x800000;
+        const CommonGuard         = 0x1000000;
+        const AirLasso            = 0x2000000;
+        const AttackN2            = 0x4000000;
+        const FinalReverseLR      = 0x8000000;
+    }
+
+    pub struct Cat3: i32 {
+        const ItemLightThrowFB4    = 0x1;
+        const ItemLightThrowHi4    = 0x2;
+        const ItemLightThrowLw4    = 0x4;
+        const ItemLightThrowHi     = 0x8;
+        const ItemLightThrowLw     = 0x10;
+        const ItemLightDrop        = 0x20;
+        const ItemLightThrowFB     = 0x40;
+        const ItemLightThrowAirFB  = 0x80;
+        const ItemLightThrowAirFB4 = 0x100;
+        const ItemLightThrowAirHi  = 0x200;
+        const ItemLightThrowAirHi4 = 0x400;
+        const ItemLightThrowAirLw  = 0x800;
+        const ItemLightThrowAirLw4 = 0x1000;
+        const ItemLightDropAir     = 0x2000;
+        const ItemHeavyThrowFB     = 0x4000;
+        const ItemGetAir           = 0x8000;
+        const SpecialSSmash        = 0x10000;
+        const SpecialSSmashDash    = 0x20000;
+
+        const ItemLightThrow       = 0x58;
+        const ItemLightThrowAir    = 0xA80;
+        const ItemLightThrow4      = 0x7;
+        const ItemLightThrow4Air   = 0x1500;
+        const ItemLightThrowAll    = 0x5F;
+        const ItemLightThrowAirAll = 0x1F80;
+    }
+
+    pub struct Cat4: i32 {
+        const SpecialNCommand       = 0x1;
+        const SpecialN2Command      = 0x2;
+        const SpecialSCommand       = 0x4;
+        const SpecialHiCommand      = 0x8;
+        const Command6N6            = 0x10;
+        const Command4N4            = 0x20;
+        const AttackCommand1        = 0x40;
+        const SpecialHi2Command     = 0x80;
+        const SuperSpecialCommand   = 0x100;
+        const SuperSpecialRCommand  = 0x200;
+        const SuperSpecial2Command  = 0x400;
+        const SuperSpecial2RCommand = 0x800;
+        const Command623NB          = 0x1000;
+        const Command623Strict      = 0x2000;
+        const Command623ALong       = 0x4000;
+        const Command623BLong       = 0x8000;
+        const Command623A           = 0x10000;
+        const Command2              = 0x20000;
+        const Command3              = 0x40000;
+        const Command1              = 0x80000;
+        const Command6              = 0x100000;
+        const Command4              = 0x200000;
+        const Command8              = 0x400000;
+        const Command9              = 0x800000;
+        const Command7              = 0x1000000;
+        const Command6N6AB          = 0x2000000;
+        const Command323Catch       = 0x4000000;
+    }
+
+    pub struct PadFlag: i32 {
+        const AttackTrigger  = 0x1;
+        const AttrckRelease  = 0x2;
+        const SpecialTrigger = 0x4;
+        const SpecialRelease = 0x8;
+        const JumpTrigger    = 0x10;
+        const JumpRelease    = 0x20;
+        const GuardTrigger   = 0x40;
+        const GuardRelease   = 0x80;
+    }
+
+    pub struct Buttons: i32 {
+        const Attack      = 0x1;
+        const Special     = 0x2;
+        const Jump        = 0x4;
+        const Guard       = 0x8;
+        const Catch       = 0x10;
+        const Smash       = 0x20;
+        const JumpMini    = 0x40;
+        const CStickOn    = 0x80;
+        const StockShare  = 0x100;
+        const AttackRaw   = 0x200;
+        const AppealHi    = 0x400;
+        const SpecialRaw  = 0x800;
+        const AppealLw    = 0x1000;
+        const AppealSL    = 0x2000;
+        const AppealSR    = 0x4000;
+        const FlickJump   = 0x8000;
+        const GuardHold   = 0x10000;
+        const SpecialRaw2 = 0x20000;
+        // We leave a blank at 0x4000 because the internal control mapping will map 1 << InputKind to the button bitfield, and so our shorthop button
+        // would get mapped to TiltAttack (issue #776)
+        const CStickOverride = 0x80000;
+
+        const SpecialAll  = 0x20802;
+        const AttackAll   = 0x201;
+        const AppealAll   = 0x7400;
+    }
+}
+
+/// Enum for the kinds of controls that are mapped
+/// Can map any of these over any button
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum InputKind {
+    Attack = 0x0,
+    Special = 0x1,
+    Jump = 0x2,
+    Guard = 0x3,
+    Grab = 0x4,
+    SmashAttack = 0x5,
+    AppealHi = 0xA,
+    AppealS = 0xB,
+    AppealLw = 0xC,
+    Unset = 0xD
+}
+
+/// 0x50 Byte struct containing the information for controller mappings
+#[derive(Debug)]
+#[repr(C)]
+pub struct ControllerMapping {
+    pub gc_l: InputKind,
+    pub gc_r: InputKind,
+    pub gc_z: InputKind,
+    pub gc_dup: InputKind,
+    pub gc_dlr: InputKind,
+    pub gc_ddown: InputKind,
+    pub gc_a: InputKind,
+    pub gc_b: InputKind,
+    pub gc_cstick: InputKind,
+    pub gc_y: InputKind,
+    pub gc_x: InputKind,
+    pub gc_rumble: bool,
+    pub gc_absmash: u8,
+    pub gc_tapjump: bool,
+    pub gc_sensitivity: u8,
+    // 0xF
+    pub pro_l: InputKind,
+    pub pro_r: InputKind,
+    pub pro_zl: InputKind,
+    pub pro_zr: InputKind,
+    pub pro_dup: InputKind,
+    pub pro_dlr: InputKind,
+    pub pro_ddown: InputKind,
+    pub pro_a: InputKind,
+    pub pro_b: InputKind,
+    pub pro_cstick: InputKind,
+    pub pro_x: InputKind,
+    pub pro_y: InputKind,
+    pub pro_rumble: bool,
+    pub pro_absmash: u8,
+    pub pro_tapjump: bool,
+    pub pro_sensitivity: u8,
+    // 0x1F
+    pub joy_shoulder: InputKind,
+    pub joy_zshoulder: InputKind,
+    pub joy_sl: InputKind,
+    pub joy_sr: InputKind,
+    pub joy_up: InputKind,
+    pub joy_right: InputKind,
+    pub joy_left: InputKind,
+    pub joy_down: InputKind,
+    pub joy_rumble: bool,
+    pub joy_absmash: u8,
+    pub joy_tapjump: bool,
+    pub joy_sensitivity: u8,
+    // 0x2B
+    pub _2b: u8,
+    pub _2c: u8,
+    pub _2d: u8,
+    pub _2e: u8,
+    pub _2f: u8,
+    pub _30: u8,
+    pub _31: u8,
+    pub _32: u8,
+    pub is_absmash: bool,
+    pub _34: [u8; 0x1C],
+}
+
+/// Controller class used internally by the game
+#[repr(C)]
+pub struct Controller {
+    pub vtable: *const u64,
+    pub current_buttons: ButtonBitfield,
+    pub previous_buttons: ButtonBitfield,
+    pub left_stick_x: f32,
+    pub left_stick_y: f32,
+    pub left_trigger: f32,
+    pub _left_padding: u32,
+    pub right_stick_x: f32,
+    pub right_stick_y: f32,
+    pub right_trigger: f32,
+    pub _right_padding: u32,
+    pub gyro: [f32; 4],
+    pub button_timespan: AutorepeatInfo,
+    pub lstick_timespan: AutorepeatInfo,
+    pub rstick_timespan: AutorepeatInfo,
+    pub just_down: ButtonBitfield,
+    pub just_release: ButtonBitfield,
+    pub autorepeat_keys: u32,
+    pub autorepeat_threshold: u32,
+    pub autorepeat_initial_press_threshold: u32,
+    pub style: ControllerStyle,
+    pub controller_id: u32,
+    pub primary_controller_color1: u32,
+    pub primary_controller_color2: u32,
+    pub secondary_controller_color1: u32,
+    pub secondary_controller_color2: u32,
+    pub led_pattern: u8,
+    pub button_autorepeat_initial_press: bool,
+    pub lstick_autorepeat_initial_press: bool,
+    pub rstick_autorepeat_initial_press: bool,
+    pub is_valid_controller: bool,
+    pub _xB9: [u8; 2],
+    pub is_connected: bool,
+    pub is_left_connected: bool,
+    pub is_right_connected: bool,
+    pub is_wired: bool,
+    pub is_left_wired: bool,
+    pub is_right_wired: bool,
+    pub _xC1: [u8; 3],
+    pub npad_number: u32,
+    pub _xC8: [u8; 8],
+}
+
+/// Re-ordered bitfield the game uses for buttons
+#[bitfield]
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct ButtonBitfield {
+    pub dpad_up: bool,
+    pub dpad_right: bool,
+    pub dpad_down: bool,
+    pub dpad_left: bool,
+    pub x: bool,
+    pub a: bool,
+    pub b: bool,
+    pub y: bool,
+    pub l: bool,
+    pub r: bool,
+    pub zl: bool,
+    pub zr: bool,
+    pub left_sl: bool,
+    pub left_sr: bool,
+    pub right_sl: bool,
+    pub right_sr: bool,
+    pub stick_l: bool,
+    pub stick_r: bool,
+    pub plus: bool,
+    pub minus: bool,
+    pub l_up: bool,
+    pub l_right: bool,
+    pub l_down: bool,
+    pub l_left: bool,
+    pub r_up: bool,
+    pub r_right: bool,
+    pub r_down: bool,
+    pub r_left: bool,
+    pub real_digital_l: bool,
+    pub real_digital_r: bool,
+    pub unused: B2,
+}
+
+#[repr(C)]
+pub struct AutorepeatInfo {
+    field: [u8; 0x18],
+}
+
+/// 8 byte struct containig all button inputs
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct MappedInputs {
+    pub buttons: Buttons,
+    pub lstick_x: i8,
+    pub lstick_y: i8,
+    pub rstick_x: i8,
+    pub rstick_y: i8,
+}
+
+/// Controller style declaring what kind of controller is being used
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[repr(u32)]
+pub enum ControllerStyle {
+    Handheld = 0x1,
+    DualJoycon = 0x2,
+    LeftJoycon = 0x3,
+    RightJoycon = 0x4,
+    ProController = 0x5,
+    DebugPag = 0x6, // I assume
+    GCController = 0x7,
+}

--- a/WuBor-Utils/src/lib.rs
+++ b/WuBor-Utils/src/lib.rs
@@ -2,3 +2,4 @@ pub mod vars;
 pub mod wua_bind;
 pub mod table_const;
 pub mod cancels;
+pub mod controls;

--- a/src/fighter/common/mod.rs
+++ b/src/fighter/common/mod.rs
@@ -5,12 +5,12 @@ pub mod agent_inits;
 pub mod param;
 // pub mod command_inputs;
 mod vtable_hook;
-// mod energy;
+mod energy;
 
 pub fn install() {
     frame::install();
     status::install();
     agent_status::install();
     vtable_hook::install();
-    // energy::install();
+    energy::install();
 }

--- a/src/fighter/common/status.rs
+++ b/src/fighter/common/status.rs
@@ -11,6 +11,7 @@ mod passive;
 mod cliff;
 mod appeal;
 mod rebirth;
+mod sub;
 mod sub_transitions;
 mod sub_fighter;
 
@@ -28,6 +29,7 @@ pub fn install() {
     cliff::install();
     appeal::install();
     rebirth::install();
+    sub::install();
     sub_transitions::install();
     sub_fighter::install();
 }

--- a/src/fighter/common/status/movement/jump.rs
+++ b/src/fighter/common/status/movement/jump.rs
@@ -1,5 +1,7 @@
 use crate::imports::status_imports::*;
 use super::super::super::param;
+use wubor_utils::controls::*;
+use std::arch::asm;
 
 #[skyline::hook(replace = L2CFighterCommon_status_Jump_sub)]
 unsafe fn status_jump_sub(fighter: &mut L2CFighterCommon, param_1: L2CValue, param_2: L2CValue) -> L2CValue {
@@ -165,6 +167,110 @@ unsafe fn status_end_jump(_fighter: &mut L2CFighterCommon) -> L2CValue {
     0.into()
 }
 
+#[skyline::hook(offset = 0x6ce6b8, inline)]
+unsafe fn jump1_stick_x_hook(ctx: &mut skyline::hooks::InlineCtx) {
+    let control_module = *ctx.registers[0].x.as_ref();
+    let boma = *(control_module as *mut *mut BattleObjectModuleAccessor).add(1);
+    let left_stick_x = if Buttons::from_bits_unchecked(ControlModule::get_button(boma)).intersects(Buttons::CStickOverride) {
+        ControlModule::get_sub_stick_x(boma)
+    }
+    else {
+        ControlModule::get_stick_x(boma)
+    };
+    asm!("fmov s0, w8", in("w8") left_stick_x)
+}
+
+#[skyline::hook(offset = 0x6d19a4, inline)]
+unsafe fn jump2_stick_x_hook(ctx: &mut skyline::hooks::InlineCtx) {
+    let control_module = *ctx.registers[0].x.as_ref();
+    let boma = *(control_module as *mut *mut BattleObjectModuleAccessor).add(1);
+    let left_stick_x = if Buttons::from_bits_unchecked(ControlModule::get_button(boma)).intersects(Buttons::CStickOverride) {
+        ControlModule::get_sub_stick_x(boma)
+    }
+    else {
+        ControlModule::get_stick_x(boma)
+    };
+    asm!("fmov s0, w8", in("w8") left_stick_x)
+}
+
+#[skyline::hook(offset = 0x6d1af0, inline)]
+unsafe fn jump3_stick_x_hook(ctx: &mut skyline::hooks::InlineCtx) {
+    let control_module = *ctx.registers[0].x.as_ref();
+    let boma = *(control_module as *mut *mut BattleObjectModuleAccessor).add(1);
+    let left_stick_x = if Buttons::from_bits_unchecked(ControlModule::get_button(boma)).intersects(Buttons::CStickOverride) {
+        ControlModule::get_sub_stick_x(boma)
+    }
+    else {
+        ControlModule::get_stick_x(boma)
+    };
+    asm!("fmov s0, w8", in("w8") left_stick_x)
+}
+
+#[skyline::hook(offset = 0x6d0434, inline)]
+unsafe fn jump4_stick_x_hook(ctx: &mut skyline::hooks::InlineCtx) {
+    let control_module = *ctx.registers[0].x.as_ref();
+    let boma = *(control_module as *mut *mut BattleObjectModuleAccessor).add(1);
+    let left_stick_x = if Buttons::from_bits_unchecked(ControlModule::get_button(boma)).intersects(Buttons::CStickOverride) {
+        ControlModule::get_sub_stick_x(boma)
+    }
+    else {
+        ControlModule::get_stick_x(boma)
+    };
+    asm!("fmov s0, w8", in("w8") left_stick_x)
+}
+
+#[skyline::hook(offset = 0x6ce7b0, inline)]
+unsafe fn jump_aerial_stick_x_hook(ctx: &mut skyline::hooks::InlineCtx) {
+    let control_module = *ctx.registers[0].x.as_ref();
+    let boma = *(control_module as *mut *mut BattleObjectModuleAccessor).add(1);
+    let left_stick_x = if Buttons::from_bits_unchecked(ControlModule::get_button(boma)).intersects(Buttons::CStickOverride) {
+        ControlModule::get_sub_stick_x(boma)
+    }
+    else {
+        ControlModule::get_stick_x(boma)
+    };
+    asm!("fmov s0, w8", in("w8") left_stick_x)
+}
+
+#[skyline::hook(offset = 0x6d05ac, inline)]
+unsafe fn jump_aerial_2_stick_x_hook(ctx: &mut skyline::hooks::InlineCtx) {
+    let control_module = *ctx.registers[0].x.as_ref();
+    let boma = *(control_module as *mut *mut BattleObjectModuleAccessor).add(1);
+    let left_stick_x = if Buttons::from_bits_unchecked(ControlModule::get_button(boma)).intersects(Buttons::CStickOverride) {
+        ControlModule::get_sub_stick_x(boma)
+    }
+    else {
+        ControlModule::get_stick_x(boma)
+    };
+    asm!("fmov s0, w8", in("w8") left_stick_x)
+}
+
+#[skyline::hook(offset = 0x6d115c, inline)]
+unsafe fn jump_aerial_3_stick_x_hook(ctx: &mut skyline::hooks::InlineCtx) {
+    let control_module = *ctx.registers[0].x.as_ref();
+    let boma = *(control_module as *mut *mut BattleObjectModuleAccessor).add(1);
+    let left_stick_x = if Buttons::from_bits_unchecked(ControlModule::get_button(boma)).intersects(Buttons::CStickOverride) {
+        ControlModule::get_sub_stick_x(boma)
+    }
+    else {
+        ControlModule::get_stick_x(boma)
+    };
+    asm!("fmov s0, w8", in("w8") left_stick_x)
+}
+
+#[skyline::hook(offset = 0x6ce26c, inline)]
+unsafe fn jump_aerial_4_stick_x_hook(ctx: &mut skyline::hooks::InlineCtx) {
+    let control_module = *ctx.registers[0].x.as_ref();
+    let boma = *(control_module as *mut *mut BattleObjectModuleAccessor).add(1);    
+    let left_stick_x = if Buttons::from_bits_unchecked(ControlModule::get_button(boma)).intersects(Buttons::CStickOverride) {
+        ControlModule::get_sub_stick_x(boma)
+    }
+    else {
+        ControlModule::get_stick_x(boma)
+    };
+    asm!("fmov s0, w8", in("w8") left_stick_x)
+}
+
 fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hooks!(
@@ -178,4 +284,27 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
 
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
+
+    // Stubs ControlModule::get_stick_x calls when calculating horizontal jump velocity
+    skyline::patching::Patch::in_text(0x6ce6b8).nop();
+    skyline::patching::Patch::in_text(0x6d19a4).nop();
+    skyline::patching::Patch::in_text(0x6d1af0).nop();
+    skyline::patching::Patch::in_text(0x6d0434).nop();
+
+    // Same as above but for double jumps
+    skyline::patching::Patch::in_text(0x6ce7b0).nop();
+    skyline::patching::Patch::in_text(0x6d05ac).nop();
+    skyline::patching::Patch::in_text(0x6d115c).nop();
+    skyline::patching::Patch::in_text(0x6ce26c).nop();
+
+    skyline::install_hooks!(
+        jump1_stick_x_hook,
+        jump2_stick_x_hook,
+        jump3_stick_x_hook,
+        jump4_stick_x_hook,
+        jump_aerial_stick_x_hook,
+        jump_aerial_2_stick_x_hook,
+        jump_aerial_3_stick_x_hook,
+        jump_aerial_4_stick_x_hook,
+    );
 }

--- a/src/fighter/common/status/sub.rs
+++ b/src/fighter/common/status/sub.rs
@@ -57,7 +57,8 @@ pub unsafe fn sub_is_dive(fighter: &mut L2CFighterCommon) -> L2CValue {
         };
 
         if left_stick_y > dive_cont_value
-        || fighter.global_table[FLICK_Y].get_i32() >= dive_flick_frame_value {
+        || fighter.global_table[FLICK_Y].get_i32() >= dive_flick_frame_value
+        || fighter.global_table[FLICK_Y_DIR].get_i32() >= 0 {
             return false.into();
         }
 

--- a/src/fighter/common/status/sub.rs
+++ b/src/fighter/common/status/sub.rs
@@ -1,0 +1,82 @@
+use crate::imports::status_imports::*;
+use wubor_utils::controls::*;
+
+#[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_sub_is_dive)]
+pub unsafe fn sub_is_dive(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE) {
+        return false.into();
+    }
+
+    let status_kind = fighter.global_table[STATUS_KIND_INTERRUPT].get_i32();
+    let prev_status_kind = fighter.global_table[PREV_STATUS_KIND].get_i32();
+
+    // if status_kind == *FIGHTER_STATUS_KIND_ESCAPE_AIR
+    // && WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE) {
+    //     return false.into();
+    // }
+
+    if [*FIGHTER_STATUS_KIND_DAMAGE_FLY,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
+        *FIGHTER_STATUS_KIND_SAVING_DAMAGE_FLY,
+    ].contains(&status_kind) {
+        return false.into();
+    }
+
+    let cliff_count = WorkModule::get_int(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_CLIFF_COUNT);
+    let some_cliff_param = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), 0x189f0b0c96);
+    if cliff_count > some_cliff_param {
+        return false.into();
+    }
+
+    if KineticModule::is_enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL)
+    && !KineticModule::is_suspend_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL) {
+        let speed_y = KineticModule::get_sum_speed_y(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+        if speed_y >= 0.0 {
+            return false.into();
+        }
+
+        let mut dive_cont_value = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("dive_cont_value"));
+        let mut dive_flick_frame_value = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("dive_flick_frame_value"));
+        if [*FIGHTER_STATUS_KIND_CLIFF_CATCH_MOVE,
+            *FIGHTER_STATUS_KIND_CLIFF_CATCH,
+            *FIGHTER_STATUS_KIND_CLIFF_WAIT,
+        ].contains(&prev_status_kind) {
+            dive_cont_value = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("cliff_dive_cont_value"));
+            dive_flick_frame_value = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("cliff_dive_flick_frame_value"));
+        }
+
+        let left_stick_y = if Buttons::from_bits_unchecked(ControlModule::get_button(fighter.module_accessor)).intersects(Buttons::CStickOverride) {
+            ControlModule::get_sub_stick_y(fighter.module_accessor)
+        }
+        else {
+            ControlModule::get_stick_y(fighter.module_accessor)
+        };
+
+        if left_stick_y > dive_cont_value
+        || fighter.global_table[FLICK_Y].get_i32() >= dive_flick_frame_value {
+            return false.into();
+        }
+
+        let dive_speed_y = WorkModule::get_param_float(fighter.module_accessor, hash40("dive_speed_y"), 0);
+        if speed_y >= -dive_speed_y {
+            return true.into();
+        }
+    }
+    false.into()
+}
+
+fn nro_hook(info: &skyline::nro::NroInfo) {
+    if info.name == "common" {
+        skyline::install_hooks!(
+            sub_is_dive
+        );
+    }
+}
+
+pub fn install() {
+    skyline::nro::add_hook(nro_hook);
+}

--- a/src/system.rs
+++ b/src/system.rs
@@ -19,6 +19,8 @@ mod menu;
 mod music;
 mod fighterspecializer;
 mod engine;
+pub mod controller;
+mod modules;
 mod one_frame;
 
 fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -52,5 +54,7 @@ pub fn install() {
     music::install();
     fighterspecializer::install();
     engine::install();
+    controller::install();
+    modules::install();
     one_frame::install();
 }

--- a/src/system/controller.rs
+++ b/src/system/controller.rs
@@ -232,19 +232,28 @@ unsafe fn handle_incoming_packet(ctx: &mut skyline::hooks::InlineCtx) {
 unsafe extern "C" fn isthrowstick(fighter: &mut L2CFighterCommon) -> L2CValue {
     let mut out = fighter.local_func__fighter_status_catch_1();
     let lr = PostureModule::lr(fighter.module_accessor);
-    let stick_x = fighter.global_table[STICK_X].get_f32() * lr;
-    let stick_y = fighter.global_table[STICK_Y].get_f32();
+    let stick_x;
+    let stick_y;
+    if Buttons::from_bits_unchecked(ControlModule::get_button(fighter.module_accessor)).intersects(Buttons::CStickOverride) {
+        stick_x = ControlModule::get_sub_stick_x(fighter.module_accessor);
+        stick_y = ControlModule::get_sub_stick_y(fighter.module_accessor);
+    }
+    else {
+        stick_x = ControlModule::get_stick_x(fighter.module_accessor);
+        stick_y = ControlModule::get_stick_y(fighter.module_accessor);
+    }
+    let stick_x = stick_x * lr;
     let throw_stick_x = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("attack_lw3_stick_x"));
     let throw_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("attack_hi4_stick_y"));
     if stick_x > throw_stick_x {
-        out["f"] = true.into();
+        out["f"].assign(&true.into());
     } else if stick_x < -throw_stick_x {
-        out["b"] = true.into();
+        out["b"].assign(&true.into());
     }
     if stick_y > throw_stick_y {
-        out["hi"] = true.into();
-    } else if stick_y < throw_stick_y {
-        out["lw"] = true.into();
+        out["hi"].assign(&true.into());
+    } else if stick_y < -throw_stick_y {
+        out["lw"].assign(&true.into());
     }
     out
 }

--- a/src/system/controller.rs
+++ b/src/system/controller.rs
@@ -1,0 +1,315 @@
+use {
+    smash::{
+        lua2cpp::*,
+        hash40,
+        app::lua_bind::*,
+        lib::L2CValue
+    },
+    wubor_utils::{controls::*, table_const::*},
+};
+
+#[skyline::hook(offset = 0x16d948c, inline)]
+unsafe fn packed_packet_creation(ctx: &mut skyline::hooks::InlineCtx) {
+    *ctx.registers[22].x.as_mut() = 0x2;
+}
+
+#[skyline::hook(offset = 0x16d94c0, inline)]
+unsafe fn write_packet(ctx: &mut skyline::hooks::InlineCtx) {
+    let raw = *ctx.registers[19].x.as_ref();
+
+    let mapped_inputs = *((raw + 0x49508) as *const MappedInputs);
+    let mut packet = 0u64;
+
+    *(&mut packet as *mut u64 as *mut i8) = mapped_inputs.lstick_x;
+    *(&mut packet as *mut u64 as *mut i8).add(1) = mapped_inputs.lstick_y;
+
+    let buttons = (mapped_inputs.buttons.bits() as u64) << 16;
+    packet |= buttons;
+
+    *(&mut packet as *mut u64 as *mut i8).add(6) = mapped_inputs.rstick_x;
+    *(&mut packet as *mut u64 as *mut i8).add(7) = mapped_inputs.rstick_y;
+
+    *ctx.registers[8].x.as_mut() = packet;
+}
+
+#[repr(C)]
+struct SomeControllerStruct {
+    padding: [u8; 0x10],
+    controller: &'static mut Controller,
+}
+
+macro_rules! apply_button_mappings {
+    ($controller:ident, $mappings:ident, $(($button:ident, $mapped:ident, $kind:ident, $output:expr))*) => {{
+        let mut buttons = Buttons::empty();
+        $(
+                if $controller.current_buttons.$button() && (*$mappings).$mapped == InputKind::$kind {
+                    buttons |= $output;
+                }
+        )*
+        buttons
+    }}
+}
+
+#[skyline::hook(offset = 0x17504a0)]
+unsafe fn map_controls_hook(
+    mappings: *mut ControllerMapping,
+    player_idx: i32,
+    out: *mut MappedInputs,
+    controller_struct: &mut SomeControllerStruct,
+    arg: bool,
+) {
+    let entry_count = (*mappings.add(player_idx as usize))._34[0];
+    let _ret = if controller_struct.controller.style == ControllerStyle::GCController {
+        // Used for analog shields
+        // let is_r_press = if (*mappings.add(player_idx as usize)).gc_r == InputKind::Guard {
+        //     let press = Some(controller_struct.controller.current_buttons.r());
+        //     controller_struct.controller.current_buttons.set_r(false);
+        //     press
+        // } else {
+        //     None
+        // };
+
+        // let is_l_press = if (*mappings.add(player_idx as usize)).gc_l == InputKind::Guard {
+        //     let press = Some(controller_struct.controller.current_buttons.l());
+        //     controller_struct.controller.current_buttons.set_l(false);
+        //     press
+        // } else {
+        //     None
+        // };
+
+        let ab_smash = (*mappings.add(player_idx as usize)).gc_absmash;
+        (*mappings.add(player_idx as usize)).gc_absmash &= 1;
+        let ret = original!()(mappings, player_idx, out, controller_struct, arg);
+        (*mappings.add(player_idx as usize)).gc_absmash = ab_smash;
+
+        // if let Some(press) = is_r_press {
+        //     controller_struct.controller.current_buttons.set_r(press);
+        // }
+
+        // if let Some(press) = is_l_press {
+        //     controller_struct.controller.current_buttons.set_l(press);
+        // }
+        ret
+    } else {
+        if controller_struct.controller.style == ControllerStyle::LeftJoycon
+            || controller_struct.controller.style == ControllerStyle::RightJoycon
+        {
+            let ab_smash = (*mappings.add(player_idx as usize)).joy_absmash;
+            (*mappings.add(player_idx as usize)).joy_absmash &= 1;
+            let ret = original!()(mappings, player_idx, out, controller_struct, arg);
+            (*mappings.add(player_idx as usize)).joy_absmash = ab_smash;
+            ret
+        } else {
+            let ab_smash = (*mappings.add(player_idx as usize)).pro_absmash;
+            (*mappings.add(player_idx as usize)).pro_absmash &= 1;
+            let ret = original!()(mappings, player_idx, out, controller_struct, arg);
+            (*mappings.add(player_idx as usize)).pro_absmash = ab_smash;
+            ret
+        }
+    };
+    let controller = &mut controller_struct.controller;
+
+    //println!("entry_count vs. current: {} vs. {}", entry_count, (*mappings.add(player_idx as usize))._34[0]);
+
+    if (*out).buttons.contains(Buttons::CStickOn)
+        && (*mappings.add(player_idx as usize))._34[0] != entry_count
+    {
+        (*out).rstick_x = (controller.left_stick_x * (i8::MAX as f32)) as i8;
+        (*out).rstick_y = (controller.left_stick_y * (i8::MAX as f32)) as i8;
+        (*out).buttons |= Buttons::CStickOverride;
+    } else {
+        (*out).rstick_x = (controller.right_stick_x * (i8::MAX as f32)) as i8;
+        (*out).rstick_y = (controller.right_stick_y * (i8::MAX as f32)) as i8;
+    }
+}
+
+#[repr(C)]
+struct ControlModuleInternal {
+    vtable: *mut u8,
+    controller_index: i32,
+    buttons: Buttons,
+    stick_x: f32,
+    stick_y: f32,
+    padding: [f32; 2],
+    unk: [u32; 8],
+    clamped_lstick_x: f32,
+    clamped_lstick_y: f32,
+    padding2: [f32; 2],
+    clamped_rstick_x: f32,
+    clamped_rstick_y: f32,
+}
+
+static mut LAST_ALT_STICK: [f32; 2] = [0.0, 0.0];
+static mut LAST_ANALOG: f32 = 0.0;
+
+pub unsafe fn get_mapped_controller_inputs_from_id(player: usize) -> &'static MappedInputs {
+    let base = *((skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as *mut u8)
+        .add(0x52c30f0) as *const u64);
+    &*((base + 0x2b8 + 0x8 * (player as u64)) as *const MappedInputs)
+}
+
+#[skyline::hook(offset = 0x3f7220)]
+unsafe fn parse_inputs(this: &mut ControlModuleInternal) {
+    const NEUTRAL: f32 = 0.2;
+    const CLAMP_MAX: f32 = 120.0;
+
+    // println!("this: {:#x}", this as *mut ControlModuleInternal as u64);
+
+    if this.controller_index == -1 {
+        return call_original!(this);
+    }
+
+    //println!("this.controller_index: {}", this.controller_index);
+    // assert!(this.controller_index <= 7);
+
+    let inputs = get_mapped_controller_inputs_from_id(this.controller_index as usize);
+
+    let clamp_mul = 1.0 / CLAMP_MAX;
+
+    // let raw_lstick_x = ((inputs.lstick_x as f32) * clamp_mul).clamp(-1.0, 1.0);
+    // let raw_lstick_y = ((inputs.lstick_y as f32) * clamp_mul).clamp(-1.0, 1.0);
+
+    // let raw_lstick_x = if raw_lstick_x.abs() >= NEUTRAL { raw_lstick_x } else { 0.0 };
+    // let raw_lstick_y = if raw_lstick_y.abs() >= NEUTRAL { raw_lstick_y } else { 0.0 };
+
+    let raw_rstick_x = ((inputs.rstick_x as f32) * clamp_mul).clamp(-1.0, 1.0);
+    let raw_rstick_y = ((inputs.rstick_y as f32) * clamp_mul).clamp(-1.0, 1.0);
+
+    LAST_ALT_STICK[0] = if raw_rstick_x.abs() >= NEUTRAL {
+        raw_rstick_x
+    } else {
+        0.0
+    };
+    LAST_ALT_STICK[1] = if raw_rstick_y.abs() >= NEUTRAL {
+        raw_rstick_y
+    } else {
+        0.0
+    };
+
+    LAST_ANALOG = ((inputs.buttons.bits() >> 22) & 1023) as f32 / 1023.0;
+
+    call_original!(this)
+}
+
+#[skyline::hook(offset = 0x6b9c5c, inline)]
+unsafe fn after_exec(ctx: &skyline::hooks::InlineCtx) {
+    let module = *ctx.registers[19].x.as_ref();
+    let internal_class = *(module as *const u64).add(0x110 / 0x8);
+    *(internal_class as *mut f32).add(0x40 / 0x4) = LAST_ALT_STICK[0];
+    *(internal_class as *mut f32).add(0x44 / 0x4) = LAST_ALT_STICK[1];
+    *(internal_class as *mut f32).add(0x48 / 0x4) = LAST_ANALOG;
+}
+
+#[skyline::hook(offset = 0x16d7ee4, inline)]
+unsafe fn handle_incoming_packet(ctx: &mut skyline::hooks::InlineCtx) {
+    let packet = *ctx.registers[15].x.as_ref();
+
+    let mut inputs = MappedInputs {
+        buttons: Buttons::empty(),
+        lstick_x: 0,
+        lstick_y: 0,
+        rstick_x: 0,
+        rstick_y: 0,
+    };
+
+    let raw_buttons = ((packet >> 16) & 0xFFFF_FFFF) as u32;
+    let lstick_x = (packet & 0xFF) as i8;
+    let lstick_y = ((packet & 0xFF00) >> 8) as i8;
+    let rstick_x = ((packet >> 0x30) & 0xFF) as i8;
+    let rstick_y = ((packet >> 0x38) & 0xFF) as i8;
+
+    inputs.buttons = Buttons::from_bits_unchecked(raw_buttons as _);
+    inputs.lstick_x = lstick_x;
+    inputs.lstick_y = lstick_y;
+    inputs.rstick_x = rstick_x;
+    inputs.rstick_y = rstick_y;
+
+    *ctx.registers[13].x.as_mut() = std::mem::transmute(inputs);
+}
+
+/// fix throws not respecting the cstick, especially dk cargo throw
+#[skyline::hook(replace = L2CFighterCommon_IsThrowStick)]
+unsafe extern "C" fn isthrowstick(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let mut out = fighter.local_func__fighter_status_catch_1();
+    let lr = PostureModule::lr(fighter.module_accessor);
+    let stick_x = fighter.global_table[STICK_X].get_f32() * lr;
+    let stick_y = fighter.global_table[STICK_Y].get_f32();
+    let throw_stick_x = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("attack_lw3_stick_x"));
+    let throw_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("attack_hi4_stick_y"));
+    if stick_x > throw_stick_x {
+        out["f"] = true.into();
+    } else if stick_x < -throw_stick_x {
+        out["b"] = true.into();
+    }
+    if stick_y > throw_stick_y {
+        out["hi"] = true.into();
+    } else if stick_y < throw_stick_y {
+        out["lw"] = true.into();
+    }
+    out
+}
+
+static mut GC_TRIGGERS: [f32; 2] = [0.0, 0.0];
+
+#[skyline::hook(offset = 0x3665e2c, inline)]
+unsafe fn post_gamecube_process(ctx: &skyline::hooks::InlineCtx) {
+    let state: *mut skyline::nn::hid::NpadGcState =
+        (ctx as *const _ as *mut u8).add(0x100) as *mut _;
+    let _controller: *mut Controller = *ctx.registers[19].x.as_ref() as _;
+
+    GC_TRIGGERS[0] = (*state).LTrigger as f32 / i16::MAX as f32;
+    GC_TRIGGERS[1] = (*state).RTrigger as f32 / i16::MAX as f32;
+}
+
+#[skyline::hook(offset = 0x3665c8c, inline)]
+unsafe fn apply_triggers(ctx: &skyline::hooks::InlineCtx) {
+    let controller: *mut Controller = *ctx.registers[19].x.as_ref() as _;
+    (*controller).left_trigger = GC_TRIGGERS[0];
+    (*controller).right_trigger = GC_TRIGGERS[1];
+    GC_TRIGGERS = [0.0, 0.0];
+}
+
+#[skyline::hook(offset = 0x3665e60, inline)]
+unsafe fn analog_trigger_l(ctx: &mut skyline::hooks::InlineCtx) {
+    if *ctx.registers[9].x.as_ref() & 0x40 != 0 {
+        let controller: *mut Controller = *ctx.registers[19].x.as_ref() as _;
+        (*controller).current_buttons.set_real_digital_l(true);
+        *ctx.registers[11].x.as_mut() = 0;
+    } else {
+        *ctx.registers[11].w.as_mut() = 0x27FF;
+    }
+}
+
+#[skyline::hook(offset = 0x3665e74, inline)]
+unsafe fn analog_trigger_r(ctx: &mut skyline::hooks::InlineCtx) {
+    if *ctx.registers[8].x.as_ref() & 0x80 != 0 {
+        let controller: *mut Controller = *ctx.registers[19].x.as_ref() as _;
+        (*controller).current_buttons.set_real_digital_r(true);
+    } else {
+        *ctx.registers[11].w.as_mut() = 0x27FF;
+    }
+}
+
+fn nro_hook(info: &skyline::nro::NroInfo) {
+    if info.name == "common" {
+        skyline::install_hook!(isthrowstick);
+    }
+}
+
+pub fn install() {
+    skyline::patching::Patch::in_text(0x3665e5c).data(0xAA0903EAu32);
+    skyline::patching::Patch::in_text(0x3665e70).data(0xAA0803EAu32);
+    skyline::install_hooks!(
+        map_controls_hook,
+        analog_trigger_l,
+        analog_trigger_r,
+        packed_packet_creation,
+        write_packet,
+        parse_inputs,
+        handle_incoming_packet,
+        after_exec,
+        post_gamecube_process,
+        apply_triggers
+    );
+    skyline::nro::add_hook(nro_hook);
+}

--- a/src/system/modules.rs
+++ b/src/system/modules.rs
@@ -1,0 +1,5 @@
+mod control;
+
+pub fn install() {
+    control::install();
+}

--- a/src/system/modules/control.rs
+++ b/src/system/modules/control.rs
@@ -1,0 +1,205 @@
+use {
+    smash::{
+        app::{lua_bind::*, *},
+        lib::lua_const::*
+    },
+    wubor_utils::controls::*
+};
+
+// #[repr(C)]
+// struct BufferState {
+//     pub on_last_frame: u32,
+//     pub should_hold: [bool; 32],
+//     pub hold_frame: [i32; 32],
+//     pub hold_frame_max: [i32; 32],
+// }
+
+// impl BufferState {
+//     pub fn new() -> Self {
+//         Self {
+//             on_last_frame: 0,
+//             should_hold: [false; 32],
+//             hold_frame: [0; 32],
+//             hold_frame_max: [-1; 32],
+//         }
+//     }
+
+//     pub fn clear(&mut self) {
+//         self.on_last_frame = 0;
+//         self.should_hold = [false; 32];
+//         self.hold_frame = [0; 32];
+//         self.hold_frame_max = [-1; 32];
+//     }
+
+//     pub fn update(
+//         &mut self,
+//         game_held: &mut [u8],
+//         max_hold_frame: i32,
+//         press_frame: i32,
+//         should_hold: bool,
+//     ) {
+//         self.on_last_frame = 0;
+//         for (idx, x) in game_held.iter_mut().enumerate() {
+//             if *x != 0
+//                 && (self.hold_frame[idx] < press_frame
+//                     || self.should_hold[idx]
+//                     || should_hold
+//                     || *x != 1)
+//             {
+//                 self.hold_frame[idx] += 1;
+//                 if self.hold_frame[idx] < press_frame {
+//                     continue;
+//                 }
+//                 if *x == 1 {
+//                     if self.should_hold[idx] {
+//                         if self.hold_frame_max[idx] != -1
+//                             && self.hold_frame_max[idx] < self.hold_frame[idx]
+//                         {
+//                             *x = 0;
+//                             self.hold_frame[idx] = 0;
+//                             continue;
+//                         }
+//                     }
+//                 } else if should_hold {
+//                     if max_hold_frame != -1 && max_hold_frame < self.hold_frame[idx] {
+//                         *x = 0;
+//                         self.hold_frame[idx] = 0;
+//                         continue;
+//                     }
+//                 }
+//                 self.on_last_frame |= 1 << idx;
+//             } else {
+//                 self.hold_frame[idx] = 0;
+//                 *x = 0;
+//             }
+//         }
+//     }
+// }
+
+// #[repr(C)]
+// struct CommandFlagCat {
+//     flags: u32,
+//     _x4: u32,
+//     count: usize,
+//     lifetimes: *mut u8,
+//     lifetimes2: *mut u8,
+//     lifetimes3: *mut u64,
+// }
+
+// impl CommandFlagCat {
+//     fn lifetimes(&self) -> &[u8] {
+//         unsafe { std::slice::from_raw_parts(self.lifetimes, self.count) }
+//     }
+
+//     fn lifetimes_mut(&self) -> &mut [u8] {
+//         unsafe { std::slice::from_raw_parts_mut(self.lifetimes, self.count) }
+//     }
+
+//     fn lifetimes2(&self) -> &[u8] {
+//         unsafe { std::slice::from_raw_parts(self.lifetimes2, self.count) }
+//     }
+// }
+
+// #[skyline::hook(offset = offsets::get_command_flag_cat())]
+// fn get_command_flag_cat_replace(control_module: u64, cat: i32) -> u32 {
+//     let boma = unsafe { *(control_module as *mut *mut BattleObjectModuleAccessor).add(1) };
+//     let battle_object = unsafe { get_battle_object_from_id((*boma).battle_object_id) };
+
+//     if cat == 4 {
+//         if !has_input_module!(battle_object) {
+//             return 0;
+//         }
+
+//         let im = require_input_module!(battle_object);
+
+//         let mut output = 0;
+//         // this iterates across all 32 bits of the output bitmask, where valid_frames represents how many frames
+//         // left any given custom input may have left in its internal buffer state.
+//         for x in 0..32 {
+//             if im.hdr_cat.valid_frames[x] != 0 {
+//                 output |= 1 << x;
+//             }
+//         }
+
+//         return output;
+//     }
+
+//     let cats =
+//         unsafe { std::slice::from_raw_parts((control_module + 0x568) as *mut CommandFlagCat, 4) };
+
+//     let mut output = 0;
+//     let lifetimes = cats[cat as usize].lifetimes();
+//     let lifetimes2 = cats[cat as usize].lifetimes2();
+//     for x in 0..cats[cat as usize].count {
+//         if lifetimes[x] > 0 && lifetimes2[x] <= 1 {
+//             output |= 1 << x;
+//         }
+//     }
+//     output
+// }
+
+fn exec_internal(module_accessor: *mut BattleObjectModuleAccessor) {
+    unsafe {
+        // Prevent game from thinking you are inputting a flick on the frame the cstick stops overriding left stick
+        if Buttons::from_bits_unchecked(ControlModule::get_release(module_accessor)).intersects(Buttons::CStickOverride) {
+            ControlModule::reset_flick_x(module_accessor);
+            ControlModule::reset_flick_y(module_accessor);
+        }
+    }
+}
+
+#[skyline::hook(offset = 0x6babf0)]
+fn exec_command_hook(control_module: u64, flag: bool) {
+    let boma = unsafe { *(control_module as *mut *mut BattleObjectModuleAccessor).add(1) };
+
+    exec_internal(boma);
+    call_original!(control_module, flag)
+}
+
+// These 2 hooks prevent buffered nair after inputting C-stick on first few frames of jumpsquat
+// Both found in ControlModule::exec_command
+#[skyline::hook(offset = 0x6be610)]
+unsafe fn set_attack_air_stick_hook(control_module: u64, arg: u32) {
+    // This check passes on the frame FighterControlModuleImpl::reserve_on_attack_button is called
+    // Only happens during jumpsquat currently
+    let boma = *(control_module as *mut *mut BattleObjectModuleAccessor).add(1);
+    if *((control_module + 0x645) as *const bool)
+    && StatusModule::status_kind(boma) == *FIGHTER_STATUS_KIND_JUMP_SQUAT {
+        return;
+    }
+    call_original!(control_module, arg);
+}
+
+#[skyline::hook(offset = 0x6bd6a4, inline)]
+unsafe fn exec_command_reset_attack_air_kind_hook(ctx: &mut skyline::hooks::InlineCtx) {
+    let control_module = *ctx.registers[21].x.as_ref();
+    let boma = *(control_module as *mut *mut BattleObjectModuleAccessor).add(1);
+    // For some reason, the game resets your attack_air_kind value every frame
+    // even though it resets as soon as you perform an aerial attack
+    // We don't want this to reset while in jumpsquat
+    // to allow the game to use your initial C-stick input during jumpsquat for your attack_air_kind
+    if StatusModule::status_kind(boma) != *FIGHTER_STATUS_KIND_JUMP_SQUAT {
+        ControlModule::reset_attack_air_kind(boma);
+    }
+}
+
+pub fn install() {
+    // Prevents buffered C-stick aerials from triggering nair
+    skyline::patching::Patch::in_text(0x6be644).data(0x52800040);
+
+    // Prevents Aerial Kind resetting every frame
+    skyline::patching::Patch::in_text(0x6bd6a4).nop();
+
+    // Removes 10f C-stick lockout for tilt stick and special stick
+    skyline::patching::Patch::in_text(0x17527dc).data(0x2A1F03FA);
+    skyline::patching::Patch::in_text(0x17527e0).nop();
+    skyline::patching::Patch::in_text(0x17527e4).nop();
+    skyline::patching::Patch::in_text(0x17527e8).nop();
+
+    skyline::install_hooks!(
+        // get_command_flag_cat_replace,
+        exec_command_hook,
+        set_attack_air_stick_hook,
+        exec_command_reset_attack_air_kind_hook
+    );
+}


### PR DESCRIPTION
All of this code comes from HDR, with some modifications.
# Changelog
## C-Stick
* Removes C-Stick drift.
* Horizontal Jump momentum no longer takes the C-Stick into account.
* The C-Stick lockout on Tilt/Special Stick is removed.
* C-Stick Aerials should no longer use the left stick's position in most scenarios.
* The C-Stick is no longer capable of performing fast falls.
  * This includes Smash Stick, as well as cases where if you hold down on the left stick and tap upwards on the C-Stick.
  * This comes with the trade off of being unable to fast fall while the C-Stick's stick override is active.
## Other
* Fixes Digital GCC Triggers