### PR TITLE
Spinning KB Animation Repurposing

### DIFF
--- a/src/fighter/common/param.rs
+++ b/src/fighter/common/param.rs
@@ -9,6 +9,7 @@ pub mod shield {
 
 pub mod passive {
     pub const invalid_passive_damage_add : f32 = 33.0;
+    pub const invalid_passive_reaction : f32 = 45.0;
 }
 
 pub mod jump {

--- a/src/fighter/common/status/passive.rs
+++ b/src/fighter/common/status/passive.rs
@@ -10,9 +10,14 @@ unsafe fn is_enable_passive(fighter: &mut L2CFighterCommon) -> L2CValue {
 }
 
 pub unsafe fn is_bad_passive(fighter: &mut L2CFighterCommon) -> L2CValue {
-    let weight = WorkModule::get_param_float(fighter.module_accessor, hash40("weight"), 0);
-    let damage = DamageModule::damage(fighter.module_accessor, 0);
-    (weight + param::passive::invalid_passive_damage_add <= damage).into()
+    // let weight = WorkModule::get_param_float(fighter.module_accessor, hash40("weight"), 0);
+    // let damage = DamageModule::damage(fighter.module_accessor, 0);
+    // (weight + param::passive::invalid_passive_damage_add <= damage).into()
+    fighter.clear_lua_stack();
+    lua_args!(fighter, hash40("reaction_frame"));
+    sv_information::damage_log_value(fighter.lua_state_agent);
+    let reaction_frame = fighter.pop_lua_stack(1).get_f32();
+    (reaction_frame >= param::passive::invalid_passive_reaction).into()
 }
 
 // #[skyline::hook(replace = L2CFighterCommon_sub_check_passive_button)]


### PR DESCRIPTION
Instead of being forced into the spinning KB animation when you take a certain amount of damage, it now applies when you get launched with 45 frames of hitstun or more.