### PR TITLE
Mythra Dodge Fixes

### DIFF
--- a/src/fighter/elight/acmd/escape.rs
+++ b/src/fighter/elight/acmd/escape.rs
@@ -1,5 +1,9 @@
 use crate::imports::acmd_imports::*;
 
+#[acmd_script( agent = "elight", script = "game_escapen", category = ACMD_GAME, low_priority )]
+unsafe fn elight_escapen(_agent: &mut L2CAgentBase) {
+}
+
 #[acmd_script( agent = "elight", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn elight_escapeairslide(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 15.0);
@@ -28,6 +32,8 @@ unsafe fn elight_escapeairslideforesight(agent: &mut L2CAgentBase) {
 
 pub fn install() {
     install_acmd_scripts!(
+        elight_escapen,
+
         elight_escapeairslide,
         elight_escapeairslideforesight
     );

--- a/src/fighter/elight/acmd/escape.rs
+++ b/src/fighter/elight/acmd/escape.rs
@@ -4,6 +4,18 @@ use crate::imports::acmd_imports::*;
 unsafe fn elight_escapen(_agent: &mut L2CAgentBase) {
 }
 
+#[acmd_script( agent = "elight", script = "game_escapef", category = ACMD_GAME, low_priority )]
+unsafe fn elight_escapef(agent: &mut L2CAgentBase) {
+    frame(agent.lua_state_agent, 16.0);
+    if macros::is_excute(agent) {
+        macros::REVERSE_LR(agent);
+    }
+}
+
+#[acmd_script( agent = "elight", script = "game_escapeb", category = ACMD_GAME, low_priority )]
+unsafe fn elight_escapeb(_agent: &mut L2CAgentBase) {
+}
+
 #[acmd_script( agent = "elight", script = "game_escapeairslide", category = ACMD_GAME, low_priority )]
 unsafe fn elight_escapeairslide(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 15.0);
@@ -33,6 +45,10 @@ unsafe fn elight_escapeairslideforesight(agent: &mut L2CAgentBase) {
 pub fn install() {
     install_acmd_scripts!(
         elight_escapen,
+
+        elight_escapef,
+
+        elight_escapeb,
 
         elight_escapeairslide,
         elight_escapeairslideforesight

--- a/src/fighter/elight/status.rs
+++ b/src/fighter/elight/status.rs
@@ -1,7 +1,11 @@
+mod escape;
+
 mod special_lw;
 mod special_lw_out;
 
 pub fn install() {
+    escape::install();
+
     special_lw::install();
     special_lw_out::install();
 }

--- a/src/fighter/elight/status/escape.rs
+++ b/src/fighter/elight/status/escape.rs
@@ -1,0 +1,12 @@
+use crate::imports::status_imports::*;
+
+#[status_script(agent = "elight", status = FIGHTER_STATUS_KIND_ESCAPE, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe fn elight_escape_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.status_Escape()
+}
+
+pub fn install() {
+    install_status_scripts!(
+        elight_escape_main
+    );
+}


### PR DESCRIPTION
In vanilla, Mythra's Spotdodge and Rolls have motion rates in them, probably to forcefully give them more endlag to compensate for Foresight.
In addition, Mythra was the only character who couldn't Spotdodge Cancel Roll.

This makes her spotdodge and rolls function like every other characters', which is technically a huge buff but I'll cross that bridge when I get to Aegis Changes 2 Electric Boogaloo.