### PR TITLE
Steve Materials Rework

### DIFF
--- a/src/fighter/pickel/vtable_hook.rs
+++ b/src/fighter/pickel/vtable_hook.rs
@@ -1,8 +1,18 @@
 pub fn install() {
     // Forces the common mining pattern
     skyline::patching::Patch::in_text(0xf1076c).data(0x14000012u32);
+
     // Skips the check for what tool to mine with
     skyline::patching::Patch::in_text(0xf0f774).data(0x14000023u32);
+
     // Forces the mining tool used to be Pickaxe
     skyline::patching::Patch::in_text(0xf0f800).data(0x321F03E1u32);
+
+    // Related to Crafting Table auto-respawn
+    // Removes the link event setting the auto respawn timer
+    skyline::patching::Patch::in_text(0xf0c1ec).data(0x140003ACu32);
+    // Disables the count_down_int for the auto respawn timer
+    skyline::patching::Patch::in_text(0xf088a8).nop();
+    // Skips the auto respawn create table call
+    skyline::patching::Patch::in_text(0xf088ac).data(0x14000005u32);
 }

--- a/src/system/fighterspecializer/pickel.rs
+++ b/src/system/fighterspecializer/pickel.rs
@@ -1,11 +1,34 @@
+use crate::imports::status_imports::*;
+
 #[skyline::hook( offset = 0xf10660 )]
 pub unsafe fn is_mining_material_table_normal() -> bool {
     false
 }
 
+#[skyline::hook( offset = 0xf106f0 )]
+pub unsafe fn get_mining_material_table_result(fighter: &mut Fighter, table: i32, progress: i32) -> i32 {
+    let ret = call_original!(fighter, table, progress);
+    let module_accessor = fighter.battle_object.module_accessor;
+    let weapon = WorkModule::get_int(module_accessor, *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_HAVE_CRAFT_WEAPON_KIND);
+    let material = WorkModule::get_int(module_accessor, *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_HAVE_CRAFT_WEAPON_MATERIAL_KIND);
+    let upper_bound = if weapon != *FIGHTER_PICKEL_CRAFT_WEAPON_KIND_NONE {
+        match material {
+            0 => 1,
+            1 => 2,
+            2 => 3,
+            _ => 6
+        }
+    }
+    else {
+        1
+    };
+    ret.clamp(0, upper_bound)
+}
+
 pub fn install() {
     skyline::install_hooks!(
-        is_mining_material_table_normal
+        is_mining_material_table_normal,
+        get_mining_material_table_result
     );
     
 }


### PR DESCRIPTION
# Changelog

## General
- [ ] Steve now starts with less materials. Values are shown as (Steve/Kirby).
  - [ ] Stage Default Material (Dirt, Sand, etc): 36/4 > 18/4
  - [ ] Wood: 18/2 > 0/0
  - [ ] Stone: 0/0 > 0/0
  - [ ] Iron: 3/1 > 0/0
  - [ ] Gold: 0/0 > 0/0
  - [ ] Redstone: 2/0 > 0/0
  - [ ] Diamond: 0/0 > 0/0

## Mine
- [x] The modified "neutral" mining pattern has been returned to vanilla.
- [x] Steve can now only mine materials that his pickaxe is capable of mining. If Steve mines a material that his current tool cannot mine, he will get the strongest material that his tool can mine instead. EX. Steve is currently using a Stone pick, and is about to mine a diamond. Instead of receiving a diamond, he will receive iron instead.
  - [x] Fists: Can only mine the stage's default material and wood.
  - [x] Wood: Can mine what fists can and also stone.
  - [x] Stone: Can mine what wood can and also Iron.
  - [x] Iron/Gold/Diamon: Can mine everything.

## Craft
- [x] The crafting table will no longer automatically respawn when broken.
- [ ] The amount of materials needed to create a crafting table has been adjusted.
  - [ ] Wood: 2 > 4
  - [ ] Stone: 4 > 4
  - [ ] Iron: 1 > 2
- [x] The amount of materials needed to craft tools has been adjusted. Values are shown as (craft/repair) cost.
  - [ ] Wood: 2/1 > 4/2
  - [ ] Stone: 1/1 > 4/2
  - [ ] Iron: 4/2 > 4/2
  - [ ] Gold 4/4 > 2/2. Note that currently you only mine 2 gold in WuBor, instead of 4 like in Vanilla.
  - [ ] Diamond: 1/1 > 2/2