### PR TITLE
Restores Narukami Back to Normal

### DIFF
--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -494,7 +494,6 @@ pub mod yu { // lucina
             pub const SHADOW_FRENZY : i32 = 0x0102;
             pub const ROMAN_ON_HIT : i32 = 0x0103;
             pub const HEROIC_GRAB : i32 = 0x0104;
-            pub const COMMAND : i32 = 0x0105;
         }
         pub mod int {
             pub const SP_LEVEL : i32 = 0x0100;
@@ -524,6 +523,10 @@ pub mod yu { // lucina
         pub mod float {
             pub const SPECIAL_LW_ROMAN_MOVE : i32 = 0x1150;
         }
+
+        pub const SPECIAL_N_COMMAND       : i32 = 0x1EB + 0;
+        pub const SPECIAL_S_COMMAND       : i32 = 0x1EB + 1;
+        pub const SPECIAL_HI_COMMAND      : i32 = 0x1EB + 2;
     }
 
     pub const SP_1 : Vector3f = Vector3f{x: 0.0, y: 22.0, z: -6.0};

--- a/WuBor-Utils/src/wua_bind.rs
+++ b/WuBor-Utils/src/wua_bind.rs
@@ -710,6 +710,16 @@ pub mod MiscModule {
         unk5: i32,
         unk6: i32
     ) -> u64;
+
+    pub fn patch_vtable_function(offset: usize, function: u64) {
+        // println!("function ptr: {:#x}", function as u64);
+        let low = (function as u64 & 0xFFFFFFFF) as u32;
+        // println!("Low to Big Endian: {:#x} > {:#?}", low, low.to_be_bytes());
+        let high = (function as u64 >> 32) as u32;
+        // println!("High to Big Endian: {:#x} > {:#?}", high, high.to_be_bytes());
+        let _ = skyline::patching::Patch::in_text(offset).data(low);
+        let _ = skyline::patching::Patch::in_text(offset + 0x4).data(high);
+    }
 }
 
 extern "C" {

--- a/src/fighter/lucina/acmd/specials.rs
+++ b/src/fighter/lucina/acmd/specials.rs
@@ -106,18 +106,6 @@ unsafe extern "C" fn lucina_specialnendmax(agent: &mut L2CAgentBase) {
 }
 
 unsafe extern "C" fn lucina_specialairs1(agent: &mut L2CAgentBase) {
-    if VarModule::is_flag(agent.module_accessor, yu::instance::flag::COMMAND)
-    && spent_meter(agent.module_accessor, false) {
-        let spent = VarModule::get_float(agent.module_accessor, yu::instance::float::SPENT_SP);
-        let meter_max = VarModule::get_float(agent.module_accessor, yu::instance::float::SP_GAUGE_MAX);
-        FGCModule::update_meter(agent.module_accessor, -spent, meter_max, yu::instance::float::SP_GAUGE);
-        VarModule::set_int(agent.module_accessor, yu::instance::int::SP_FLASH_TIMER, 40);
-        VarModule::on_flag(agent.module_accessor, yu::status::flag::IS_EX);
-        sp_diff_checker(agent.module_accessor);
-    }
-    else {
-        VarModule::off_flag(agent.module_accessor, yu::status::flag::IS_EX);
-    }
     frame(agent.lua_state_agent, 1.0);
     if macros::is_excute(agent) {
         JostleModule::set_status(agent.module_accessor, false);
@@ -255,19 +243,11 @@ unsafe extern "C" fn lucina_specials2hi_exp(agent: &mut L2CAgentBase) {
 }
 
 unsafe extern "C" fn lucina_specialhi(agent: &mut L2CAgentBase) {
-    if VarModule::is_flag(agent.module_accessor, yu::instance::flag::COMMAND)
-    && spent_meter(agent.module_accessor, false) {
-        let spent = VarModule::get_float(agent.module_accessor, yu::instance::float::SPENT_SP);
-        let meter_max = VarModule::get_float(agent.module_accessor, yu::instance::float::SP_GAUGE_MAX);
-        FGCModule::update_meter(agent.module_accessor, -spent, meter_max, yu::instance::float::SP_GAUGE);
-        VarModule::set_int(agent.module_accessor, yu::instance::int::SP_FLASH_TIMER, 40);
-        VarModule::on_flag(agent.module_accessor, yu::status::flag::IS_EX);
-        sp_diff_checker(agent.module_accessor);
+    if VarModule::is_flag(agent.module_accessor, yu::status::flag::IS_EX) {
         full_invuln(agent.module_accessor, true);
         macros::FT_MOTION_RATE(agent, 2.0 / 3.0);
     }
     else {
-        VarModule::off_flag(agent.module_accessor, yu::status::flag::IS_EX);
         upper_invuln(agent.module_accessor, true);
     }
     if VarModule::is_flag(agent.module_accessor, yu::status::flag::IS_EX) {
@@ -399,14 +379,7 @@ unsafe extern "C" fn lucina_specialhi_exp(agent: &mut L2CAgentBase) {
 }
 
 unsafe extern "C" fn lucina_specialairhi(agent: &mut L2CAgentBase) {
-    if VarModule::is_flag(agent.module_accessor, yu::instance::flag::COMMAND)
-    && spent_meter(agent.module_accessor, false) {
-        let spent = VarModule::get_float(agent.module_accessor, yu::instance::float::SPENT_SP);
-        let meter_max = VarModule::get_float(agent.module_accessor, yu::instance::float::SP_GAUGE_MAX);
-        FGCModule::update_meter(agent.module_accessor, -spent, meter_max, yu::instance::float::SP_GAUGE);
-        VarModule::set_int(agent.module_accessor, yu::instance::int::SP_FLASH_TIMER, 40);
-        VarModule::on_flag(agent.module_accessor, yu::status::flag::IS_EX);
-        sp_diff_checker(agent.module_accessor);
+    if VarModule::is_flag(agent.module_accessor, yu::status::flag::IS_EX) {
         full_invuln(agent.module_accessor, true);
         macros::FT_MOTION_RATE(agent, 2.0 / 3.0);
     }
@@ -550,10 +523,6 @@ unsafe extern "C" fn lucina_specialairhi_exp(agent: &mut L2CAgentBase) {
 unsafe extern "C" fn lucina_speciallw(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 1.0);
     if macros::is_excute(agent) {
-        let spent = VarModule::get_float(agent.module_accessor, yu::instance::float::SPENT_SP);
-        let meter_max = VarModule::get_float(agent.module_accessor, yu::instance::float::SP_GAUGE_MAX);
-        FGCModule::update_meter(agent.module_accessor, -spent, meter_max, yu::instance::float::SP_GAUGE);
-        sp_diff_checker(agent.module_accessor);
         JostleModule::set_status(agent.module_accessor, false);
         KineticModule::unable_energy_all(agent.module_accessor);
         if VarModule::is_flag(agent.module_accessor, yu::instance::flag::ROMAN_ON_HIT) {
@@ -694,18 +663,6 @@ unsafe extern "C" fn lucina_speciallwhit_exp(agent: &mut L2CAgentBase) {
 unsafe extern "C" fn lucina_lightningflash(agent: &mut L2CAgentBase) {
     let mut dmg : f32;
     let kbg : i32;
-    if VarModule::is_flag(agent.module_accessor, yu::instance::flag::COMMAND)
-    && spent_meter_super(agent.module_accessor) {
-        let spent = VarModule::get_float(agent.module_accessor, yu::instance::float::SPENT_SP);
-        let meter_max = VarModule::get_float(agent.module_accessor, yu::instance::float::SP_GAUGE_MAX);
-        FGCModule::update_meter(agent.module_accessor, -spent, meter_max, yu::instance::float::SP_GAUGE);
-        VarModule::set_int(agent.module_accessor, yu::instance::int::SP_FLASH_TIMER, 40);
-        VarModule::on_flag(agent.module_accessor, yu::status::flag::IS_EX);
-        sp_diff_checker(agent.module_accessor);
-    }
-    else {
-        VarModule::off_flag(agent.module_accessor, yu::status::flag::IS_EX);
-    }
     frame(agent.lua_state_agent, 1.0);
     macros::FT_MOTION_RATE(agent, 2.0/3.0);
     frame(agent.lua_state_agent, 15.0);

--- a/src/fighter/lucina/agent_init.rs
+++ b/src/fighter/lucina/agent_init.rs
@@ -15,54 +15,46 @@ unsafe extern "C" fn yu_speciallw_pre(fighter: &mut L2CFighterCommon) -> L2CValu
 }
 
 unsafe extern "C" fn yu_check_special_command(fighter: &mut L2CFighterCommon) -> L2CValue {
-    let mut ret = false;
-    VarModule::off_flag(fighter.module_accessor, yu::instance::flag::COMMAND);
     let cat4 = fighter.global_table[CMD_CAT4].get_i32();
-    if !ret
-    && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
+
+    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
     && cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SUPER_SPECIAL2_COMMAND != 0
     && spent_meter_super(fighter.module_accessor)
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL2) {
         fighter.change_status(FIGHTER_MARTH_STATUS_KIND_SPECIAL_S4.into(), true.into());
-        ret = true;
+        return true.into();
     }
-    if !ret
-    && cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_HI_COMMAND != 0
+
+    if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_HI_COMMAND != 0
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI_COMMAND) {
-        fighter.change_status(FIGHTER_STATUS_KIND_SPECIAL_HI.into(), true.into());
-        ret = true;
+        fighter.change_status(yu::status::SPECIAL_HI_COMMAND.into(), true.into());
+        return true.into();
     }
-    if !ret
-    && cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
+
+    if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND)
     && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[CHECK_SPECIAL_N_UNIQ].clone()).get_bool() {
-        fighter.change_status(FIGHTER_STATUS_KIND_SPECIAL_N.into(), true.into());
-        ret = true;
+        fighter.change_status(yu::status::SPECIAL_N_COMMAND.into(), true.into());
+        return true.into();
     }
-    if !ret
-    && cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_S_COMMAND != 0
+
+    if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_S_COMMAND != 0
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_S_COMMAND)
     && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[CHECK_SPECIAL_S_UNIQ].clone()).get_bool() {
-        ControlModule::reset_flick_sub_x(fighter.module_accessor);
-        ControlModule::reset_main_stick(fighter.module_accessor);
-        ControlModule::reset_turn_lr(fighter.module_accessor);
-        fighter.change_status(FIGHTER_STATUS_KIND_SPECIAL_S.into(), true.into());
-        ret = true;
+        fighter.change_status(yu::status::SPECIAL_S_COMMAND.into(), true.into());
+        return true.into();
     }
-    if ret {
-        VarModule::on_flag(fighter.module_accessor, yu::instance::flag::COMMAND);
-    }
-    if !ret
-    && shadow_id(fighter.module_accessor)
+
+    if shadow_id(fighter.module_accessor)
     && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI != 0
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW_COMMAND)
     && !VarModule::is_flag(fighter.module_accessor, yu::instance::flag::SHADOW_FRENZY)
     && VarModule::get_float(fighter.module_accessor, yu::instance::float::SP_GAUGE) >= 25.0
     && VarModule::is_flag(fighter.module_accessor, yu::instance::flag::ROMAN_ON_HIT) {
         fighter.change_status(FIGHTER_MARTH_STATUS_KIND_SPECIAL_LW_HIT.into(), true.into());
-        ret = true;
+        return true.into();
     }
-    ret.into()
+    false.into()
 }
 
 unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {

--- a/src/fighter/lucina/agent_init.rs
+++ b/src/fighter/lucina/agent_init.rs
@@ -1,14 +1,6 @@
 use {
-    smash::{
-        lua2cpp::L2CFighterCommon,
-        phx::*,
-        app::lua_bind::*,
-        lib::{lua_const::*, L2CValue}
-    },
-    custom_var::*,
-    custom_cancel::*,
-    wubor_utils::{wua_bind::*, vars::*, table_const::*},
-    super::{helper::*, cancel}
+    crate::imports::status_imports::*,
+    super::helper::*
 };
 
 unsafe extern "C" fn yu_specialns_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
@@ -74,23 +66,12 @@ unsafe extern "C" fn yu_check_special_command(fighter: &mut L2CFighterCommon) ->
 }
 
 unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {
-    cancel::install();
-    VarModule::set_float(fighter.module_accessor, yu::instance::float::SP_GAUGE_MAX, 100.0);
     fighter.global_table[CHECK_SPECIAL_N_UNIQ].assign(&L2CValue::Ptr(yu_specialns_pre as *const () as _));
     fighter.global_table[CHECK_SPECIAL_S_UNIQ].assign(&L2CValue::Ptr(yu_specialns_pre as *const () as _));
     fighter.global_table[CHECK_SPECIAL_LW_UNIQ].assign(&L2CValue::Ptr(yu_speciallw_pre as *const () as _));
     fighter.global_table[CHECK_SPECIAL_COMMAND].assign(&L2CValue::Ptr(yu_check_special_command as *const () as _));
-    FGCModule::set_command_input_button(fighter.module_accessor, 0, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 1, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 2, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 3, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 8, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 9, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 10, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 11, 2);
 }
 
 pub fn install(agent: &mut smashline::Agent) {
-    CustomCancelManager::initialize_agent(Hash40::new("fighter_kind_lucina"));
     agent.on_start(on_start);
 }

--- a/src/fighter/lucina/cancel.rs
+++ b/src/fighter/lucina/cancel.rs
@@ -85,6 +85,7 @@ unsafe extern "C" fn lucina_attackair_set_cancels(fighter: &mut L2CFighterCommon
 
 pub fn install() {
     let agent = Hash40::new("fighter_kind_lucina");
+    CustomCancelManager::initialize_agent(agent);
     CustomCancelManager::add_cancel_info(
         agent,
         *FIGHTER_STATUS_KIND_ATTACK,

--- a/src/fighter/lucina/mod.rs
+++ b/src/fighter/lucina/mod.rs
@@ -2,9 +2,10 @@ mod acmd;
 mod frame;
 mod status;
 mod agent_init;
+mod vtable_hook;
 pub mod helper;
 pub mod vl;
-pub mod cancel;
+mod cancel;
 
 pub fn install() {
     let agent = &mut smashline::Agent::new("lucina");
@@ -12,5 +13,7 @@ pub fn install() {
     frame::install(agent);
     status::install(agent);
     agent_init::install(agent);
+    vtable_hook::install();
+    cancel::install();
     agent.install();
 }

--- a/src/fighter/lucina/status/attack_dash.rs
+++ b/src/fighter/lucina/status/attack_dash.rs
@@ -47,8 +47,7 @@ unsafe extern "C" fn lucina_attack_dash_main_loop(fighter: &mut L2CFighterCommon
     }
     if VarModule::is_flag(fighter.module_accessor, yu::status::flag::ATTACK_DASH_BIG_GAMBLE_TRANSITION)
     && VarModule::is_flag(fighter.module_accessor, yu::status::flag::ATTACK_DASH_BIG_GAMBLE) {
-        VarModule::on_flag(fighter.module_accessor, yu::instance::flag::COMMAND);
-        fighter.change_status(FIGHTER_STATUS_KIND_SPECIAL_HI.into(), true.into());
+        fighter.change_status(yu::status::SPECIAL_HI_COMMAND.into(), true.into());
         return 1.into();
     }
     fighter.status_AttackDash_Main()

--- a/src/fighter/lucina/status/special_lw.rs
+++ b/src/fighter/lucina/status/special_lw.rs
@@ -1,6 +1,11 @@
 use crate::imports::status_imports::*;
+use super::super::helper::*;
 
 unsafe extern "C" fn lucina_speciallw_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let spent = VarModule::get_float(fighter.module_accessor, yu::instance::float::SPENT_SP);
+    let meter_max = VarModule::get_float(fighter.module_accessor, yu::instance::float::SP_GAUGE_MAX);
+    FGCModule::update_meter(fighter.module_accessor, -spent, meter_max, yu::instance::float::SP_GAUGE);
+    sp_diff_checker(fighter.module_accessor);
     VarModule::off_flag(fighter.module_accessor, yu::status::flag::SPECIAL_LW_DECIDE_ROMAN_DIREC);
     VarModule::off_flag(fighter.module_accessor, yu::status::flag::SPECIAL_LW_ROMAN_MOVE);
     if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {

--- a/src/fighter/lucina/status/special_n.rs
+++ b/src/fighter/lucina/status/special_n.rs
@@ -6,15 +6,6 @@ unsafe extern "C" fn lucina_special_n_main(fighter: &mut L2CFighterCommon) -> L2
     WorkModule::off_flag(fighter.module_accessor, *FIGHTER_MARTH_STATUS_SPECIAL_N_FLAG_CHARGE_MAX);
     VarModule::on_flag(fighter.module_accessor, yu::instance::flag::DISABLE_SPECIAL_N_S);
     lucina_special_n_mot_helper(fighter);
-    if VarModule::is_flag(fighter.module_accessor, yu::instance::flag::COMMAND)
-    && spent_meter(fighter.module_accessor, false) {
-        let spent = VarModule::get_float(fighter.module_accessor, yu::instance::float::SPENT_SP);
-        let meter_max = VarModule::get_float(fighter.module_accessor, yu::instance::float::SP_GAUGE_MAX);
-        FGCModule::update_meter(fighter.module_accessor, -spent, meter_max, yu::instance::float::SP_GAUGE);
-        VarModule::set_int(fighter.module_accessor, yu::instance::int::SP_FLASH_TIMER, 40);
-        VarModule::on_flag(fighter.module_accessor, yu::status::flag::IS_EX);
-        sp_diff_checker(fighter.module_accessor);
-    }
     fighter.sub_shift_status_main(L2CValue::Ptr(lucina_special_n_main_loop as *const () as _))
 }
 
@@ -86,6 +77,44 @@ unsafe extern "C" fn lucina_special_n_main_loop(fighter: &mut L2CFighterCommon) 
     0.into()
 }
 
+unsafe extern "C" fn lucina_special_n_command_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let original = smashline::original_status(smashline::Pre, fighter, *FIGHTER_STATUS_KIND_SPECIAL_N);
+    original(fighter)
+}
+
+unsafe extern "C" fn lucina_special_n_command_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let original = smashline::original_status(smashline::Init, fighter, *FIGHTER_STATUS_KIND_SPECIAL_N);
+    original(fighter)
+}
+
+unsafe extern "C" fn lucina_special_n_command_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if spent_meter(fighter.module_accessor, false) {
+        let spent = VarModule::get_float(fighter.module_accessor, yu::instance::float::SPENT_SP);
+        let meter_max = VarModule::get_float(fighter.module_accessor, yu::instance::float::SP_GAUGE_MAX);
+        FGCModule::update_meter(fighter.module_accessor, -spent, meter_max, yu::instance::float::SP_GAUGE);
+        VarModule::set_int(fighter.module_accessor, yu::instance::int::SP_FLASH_TIMER, 40);
+        VarModule::on_flag(fighter.module_accessor, yu::status::flag::IS_EX);
+        sp_diff_checker(fighter.module_accessor);
+    }
+    lucina_special_n_main(fighter)
+}
+
+unsafe extern "C" fn lucina_special_n_command_exec(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let original = smashline::original_status(smashline::Exec, fighter, *FIGHTER_STATUS_KIND_SPECIAL_N);
+    original(fighter)
+}
+
+unsafe extern "C" fn lucina_special_n_command_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let original = smashline::original_status(smashline::End, fighter, *FIGHTER_STATUS_KIND_SPECIAL_N);
+    original(fighter)
+}
+
 pub fn install(agent: &mut smashline::Agent) {
     agent.status(smashline::Main, *FIGHTER_STATUS_KIND_SPECIAL_N, lucina_special_n_main);
+
+    agent.status(smashline::Pre, yu::status::SPECIAL_N_COMMAND, lucina_special_n_command_pre);
+    agent.status(smashline::Init, yu::status::SPECIAL_N_COMMAND, lucina_special_n_command_init);
+    agent.status(smashline::Main, yu::status::SPECIAL_N_COMMAND, lucina_special_n_command_main);
+    agent.status(smashline::Exec, yu::status::SPECIAL_N_COMMAND, lucina_special_n_command_exec);
+    agent.status(smashline::End, yu::status::SPECIAL_N_COMMAND, lucina_special_n_command_end);
 }

--- a/src/fighter/lucina/status/special_n_loop.rs
+++ b/src/fighter/lucina/status/special_n_loop.rs
@@ -22,13 +22,13 @@ unsafe extern "C" fn lucina_special_n_loop_main_loop(fighter: &mut L2CFighterCom
     }
     else {
         if MotionModule::is_end(fighter.module_accessor) {
-            if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_GROUND {
+            // if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_GROUND {
                 fighter.change_status(FIGHTER_MARTH_STATUS_KIND_SPECIAL_N_END.into(), false.into());
-            }
-            else {
-                // VarModule::on_flag(fighter.module_accessor, yu::instance::flag::HEROIC_GRAB);
-                fighter.change_status(FIGHTER_STATUS_KIND_CATCH_DASH.into(), false.into());
-            }
+            // }
+            // else {
+            //     // VarModule::on_flag(fighter.module_accessor, yu::instance::flag::HEROIC_GRAB);
+            //     fighter.change_status(FIGHTER_STATUS_KIND_CATCH_DASH.into(), false.into());
+            // }
         }
     }
     0.into()

--- a/src/fighter/lucina/status/special_s4.rs
+++ b/src/fighter/lucina/status/special_s4.rs
@@ -1,4 +1,5 @@
 use crate::imports::status_imports::*;
+use super::super::helper::*;
 
 unsafe extern "C" fn lucina_special_s4_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
     StatusModule::init_settings(
@@ -30,6 +31,14 @@ unsafe extern "C" fn lucina_special_s4_pre(fighter: &mut L2CFighterCommon) -> L2
 }
 
 unsafe extern "C" fn lucina_special_s4_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if spent_meter_super(fighter.module_accessor) {
+        let spent = VarModule::get_float(fighter.module_accessor, yu::instance::float::SPENT_SP);
+        let meter_max = VarModule::get_float(fighter.module_accessor, yu::instance::float::SP_GAUGE_MAX);
+        FGCModule::update_meter(fighter.module_accessor, -spent, meter_max, yu::instance::float::SP_GAUGE);
+        VarModule::set_int(fighter.module_accessor, yu::instance::int::SP_FLASH_TIMER, 40);
+        VarModule::on_flag(fighter.module_accessor, yu::status::flag::IS_EX);
+        sp_diff_checker(fighter.module_accessor);
+    }
     KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION);
     MotionModule::change_motion(
         fighter.module_accessor,

--- a/src/fighter/lucina/vtable_hook.rs
+++ b/src/fighter/lucina/vtable_hook.rs
@@ -1,0 +1,19 @@
+use crate::imports::status_imports::*;
+
+unsafe extern "C" fn lucina_init(_vtable: u64, fighter: &mut Fighter) {
+    let module_accessor = fighter.battle_object.module_accessor;
+    WorkModule::on_flag(module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CAN_SPECIAL_COMMAND);
+    VarModule::set_float(module_accessor, yu::instance::float::SP_GAUGE_MAX, 100.0);
+    FGCModule::set_command_input_button(module_accessor, 0, 2);
+    FGCModule::set_command_input_button(module_accessor, 1, 2);
+    FGCModule::set_command_input_button(module_accessor, 2, 2);
+    FGCModule::set_command_input_button(module_accessor, 3, 2);
+    FGCModule::set_command_input_button(module_accessor, 8, 2);
+    FGCModule::set_command_input_button(module_accessor, 9, 2);
+    FGCModule::set_command_input_button(module_accessor, 10, 2);
+    FGCModule::set_command_input_button(module_accessor, 11, 2);
+}
+
+pub fn install() {
+    MiscModule::patch_vtable_function(0x4fe5fc0, lucina_init as u64);
+}


### PR DESCRIPTION
# Changelog

Narukami didn't quite survive on the transition to SMASHLINE2, so we've revived him from the dead using dark arts.

Fixes his inability to use command inputs, as well as refactors his command inputs to use unique statuses, relying less on persistent variables to handle if the command input version was used.