### PR TITLE
Dash and Pivot Adjustments

### DIFF
--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -183,7 +183,6 @@ pub mod damage_fly_roll {
 pub mod dash {
     pub mod flag {
         pub const DISABLE_RUN : i32 = 0x1051;
-        pub const DISABLE_PIVOT_TURN_DASH : i32 = 0x1052;
     }
 }
 

--- a/src/fighter/common/status/movement/dash.rs
+++ b/src/fighter/common/status/movement/dash.rs
@@ -722,7 +722,7 @@ unsafe extern "C" fn fgc_dashback_main_loop(fighter: &mut L2CFighterCommon) -> L
         let re_dash_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("re_dash_frame")) as f32;
         re_dash_frame <= frame
     } {
-        fighter.change_status(FIGHTER_STATUS_KIND_TURN.into(), true.into());
+        fighter.change_status(FIGHTER_STATUS_KIND_TURN_DASH.into(), true.into());
         return 1.into();
     }
 

--- a/src/fighter/common/status/movement/dash.rs
+++ b/src/fighter/common/status/movement/dash.rs
@@ -431,7 +431,7 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, par
     }
 
     if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH) 
-    && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_TURN_DASH != 0 {
+    && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_TURN != 0 {
         fighter.change_status(FIGHTER_STATUS_KIND_TURN.into(), true.into());
         return 1.into();
     }
@@ -722,7 +722,7 @@ unsafe extern "C" fn fgc_dashback_main_loop(fighter: &mut L2CFighterCommon) -> L
         let re_dash_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("re_dash_frame")) as f32;
         re_dash_frame <= frame
     } {
-        fighter.change_status(FIGHTER_STATUS_KIND_TURN_DASH.into(), true.into());
+        fighter.change_status(FIGHTER_STATUS_KIND_TURN.into(), true.into());
         return 1.into();
     }
 

--- a/src/fighter/common/status/movement/dash.rs
+++ b/src/fighter/common/status/movement/dash.rs
@@ -115,6 +115,7 @@ unsafe extern "C" fn status_turndash_sub(fighter: &mut L2CFighterCommon) {
 
 #[skyline::hook(replace = L2CFighterCommon_status_DashCommon)]
 unsafe extern "C" fn status_dashcommon(fighter: &mut L2CFighterCommon) {
+    ControlModule::clear_command(fighter.module_accessor, false);
     VarModule::off_flag(fighter.module_accessor, dash::flag::DISABLE_RUN);
     WorkModule::enable_transition_term_group(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_GROUP_CHK_GROUND_JUMP);
     let transitions = [
@@ -149,7 +150,7 @@ unsafe extern "C" fn status_dashcommon(fighter: &mut L2CFighterCommon) {
         *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_COMMAND_623NB,
         *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_STAND,
         *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_SQUAT,
-        *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN,
+        // *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN,
         *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH,
         // *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_B,
         // *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_F,
@@ -429,17 +430,9 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, par
         }
     }
 
-    if fighter.global_table[STATUS_FRAME].get_i32() != 0
-    && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN) 
-    && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_TURN != 0 {
-        VarModule::on_flag(fighter.module_accessor, dash::flag::DISABLE_PIVOT_TURN_DASH);
-        fighter.change_status(FIGHTER_STATUS_KIND_TURN.into(), true.into());
-        return 1.into();
-    }
-
     if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH) 
     && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_TURN_DASH != 0 {
-        fighter.change_status(FIGHTER_STATUS_KIND_TURN_DASH.into(), true.into());
+        fighter.change_status(FIGHTER_STATUS_KIND_TURN.into(), true.into());
         return 1.into();
     }
 
@@ -822,7 +815,7 @@ unsafe extern "C" fn sub_dash_uniq_process_main_internal(fighter: &mut L2CFighte
     if 0 <= turn_dash_frame {
         WorkModule::dec_int(fighter.module_accessor, *FIGHTER_STATUS_DASH_WORK_INT_TURN_DASH_FRAME);
         if turn_dash_frame - 1 < 0 {
-            WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN);
+            // WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN);
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH);
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_B);
         }

--- a/src/fighter/common/status/movement/turn.rs
+++ b/src/fighter/common/status/movement/turn.rs
@@ -2,6 +2,7 @@ use crate::imports::*;
 
 #[skyline::hook(replace = L2CFighterCommon_status_pre_TurnCommon)]
 unsafe extern "C" fn status_pre_turncommon(fighter: &mut L2CFighterCommon) {
+    // Vanilla
     let groups = [
         *FIGHTER_STATUS_TRANSITION_GROUP_CHK_GROUND_SPECIAL,
         *FIGHTER_STATUS_TRANSITION_GROUP_CHK_GROUND_ITEM,
@@ -24,13 +25,6 @@ unsafe extern "C" fn status_pre_turncommon(fighter: &mut L2CFighterCommon) {
     ];
     for x in group_ex.iter() {
         WorkModule::unable_transition_term_group_ex(fighter.module_accessor, *x);
-    }
-    if [
-        *FIGHTER_STATUS_KIND_DASH,
-        *FIGHTER_STATUS_KIND_TURN_DASH
-    ].contains(&fighter.global_table[PREV_STATUS_KIND].get_i32())
-    && VarModule::is_flag(fighter.module_accessor, dash::flag::DISABLE_PIVOT_TURN_DASH) {
-        WorkModule::unable_transition_term_group_ex(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH);
     }
     WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_TURN_ATTACK_S4_REV_PAD);
     MotionModule::change_motion(

--- a/src/fighter/common/status/movement/turn.rs
+++ b/src/fighter/common/status/movement/turn.rs
@@ -39,10 +39,42 @@ unsafe extern "C" fn status_pre_turncommon(fighter: &mut L2CFighterCommon) {
     );
 }
 
+#[skyline::hook(replace = L2CFighterCommon_sub_turn_uniq_process_main)]
+unsafe extern "C" fn sub_turn_uniq_process_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_STATUS_TURN_FLAG_REVERSE);
+    let turn_frame = WorkModule::get_float(fighter.module_accessor, *FIGHTER_STATUS_TURN_WORK_FLOAT_TURN_FRAME);
+    if turn_frame <= 0.0 {
+        if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_TURN_FLAG_TURN) {
+            WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_TURN_FLAG_TURN);
+            WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_TURN_FLAG_REVERSE);
+        }
+    }
+    else {
+        WorkModule::sub_float(fighter.module_accessor, 1.0, *FIGHTER_STATUS_TURN_WORK_FLOAT_TURN_FRAME);
+    }
+    if fighter.global_table[STATUS_KIND_INTERRUPT].get_i32() != *FIGHTER_STATUS_KIND_TURN_DASH {
+        let dash_stick_x = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("dash_stick_x"));
+        let mut dash_flick_x = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("dash_flick_x"));
+        // Additional buffer if coming from dash or turn dash.
+        if [*FIGHTER_STATUS_KIND_DASH, *FIGHTER_STATUS_KIND_TURN_DASH].contains(&fighter.global_table[PREV_STATUS_KIND].get_i32()) {
+            dash_flick_x += 2;
+        }
+        let stick_x = ControlModule::get_stick_x(fighter.module_accessor);
+        let turn_lr = WorkModule::get_float(fighter.module_accessor, *FIGHTER_STATUS_TURN_WORK_FLOAT_LR);
+        let flick_x = ControlModule::get_flick_x(fighter.module_accessor);
+        if dash_stick_x < stick_x * -turn_lr
+        && flick_x & 0xff < dash_flick_x {
+            WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_TURN_FLAG_DASH);
+        }
+    }
+    0.into()
+}
+
 fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hooks!(
-            status_pre_turncommon
+            status_pre_turncommon,
+            sub_turn_uniq_process_main
         );
     }
 }


### PR DESCRIPTION
# Changelog

## Dash
- Removed the ability to dash back directly from Dash and Turn Dash. Instead, any valid "turn" input will put you into the standing turnaround state.

## Pivots
- Pivots can now transition into Turn Dash after one frame, like in previous games. This means Perfect Pivoting is truly back.
  - To prevent accidentally performing a pivot when attempting to perform a dash back during Dash or Turn Dash, the flick window for a successful dash input is extended by two frames (2 > 4).

## Input Buffer
- Lowered the tap input buffer (7 > 5). If you've played HDR, you know how this feels.