### PR TITLE
Lucario Adjustments

### DIFF
--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -425,9 +425,10 @@ pub mod lucario {
             pub const SPECIAL_N_SPIRIT_BOMB_FALLING : i32 = 0x1154;
 
             pub const SPECIAL_S_CHECK_ENHANCE : i32 = 0x1150;
-            pub const SPECIAL_S_ENHANCE : i32 = 0x1151;
-            pub const SPECIAL_S_ENABLE_GRAVITY : i32 = 0x1152;
-            pub const SPECIAL_S_POST_GRAVITY : i32 = 0x1153;
+            pub const SPECIAL_S_SET_MOTION : i32 = 0x1151;
+            pub const SPECIAL_S_ENHANCE : i32 = 0x1152;
+            pub const SPECIAL_S_ENABLE_GRAVITY : i32 = 0x1153;
+            pub const SPECIAL_S_POST_GRAVITY : i32 = 0x1154;
 
             pub const SPECIAL_HI_CANCELLED_INTO : i32 = 0x1150;
             pub const SPECIAL_HI_SUPER_DASH_CANCEL : i32 = 0x1151;

--- a/src/fighter/kirby/status/lucario.rs
+++ b/src/fighter/kirby/status/lucario.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn kirby_lucario_special_n_main(fighter: &mut L2CFighterCommon
     WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LUCARIO_INSTANCE_WORK_ID_FLAG_MOT_INHERIT);
     WorkModule::set_int64(fighter.module_accessor, hash40("special_n_start") as i64, *FIGHTER_LUCARIO_INSTANCE_WORK_ID_INT_GROUND_MOT);
     WorkModule::set_int64(fighter.module_accessor, hash40("special_air_n_start") as i64, *FIGHTER_LUCARIO_INSTANCE_WORK_ID_INT_AIR_MOT);
-    WorkModule::set_customize_no(fighter.module_accessor, 0, 0);
     kirby_lucario_special_set_kinetic(fighter);
     lucario_special_n_joint_translate(fighter);
     ControlModule::set_add_jump_mini_button_life(fighter.module_accessor, 8);
@@ -87,6 +86,7 @@ unsafe extern "C" fn kirby_lucario_special_n_main_loop(fighter: &mut L2CFighterC
         }
     }
     else {
+        ArticleModule::generate_article(fighter.module_accessor, *FIGHTER_LUCARIO_GENERATE_ARTICLE_AURABALL, false, -1);
         fighter.change_status(FIGHTER_KIRBY_STATUS_KIND_LUCARIO_SPECIAL_N_HOLD.into(), false.into());
     }
     0.into()

--- a/src/fighter/lucario/acmd/normals.rs
+++ b/src/fighter/lucario/acmd/normals.rs
@@ -1,13 +1,47 @@
 use crate::imports::*;
 
-unsafe extern "C" fn game_attack13(agent: &mut L2CAgentBase) {
+unsafe extern "C" fn game_attack11(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 1.0);
+    macros::FT_MOTION_RATE(agent, 4.0 / 5.0);
+    frame(agent.lua_state_agent, 6.0);
     macros::FT_MOTION_RATE(agent, 1.0);
+    if macros::is_excute(agent) {
+        macros::ATTACK(agent, 0, 0, Hash40::new("handl"), 2.5, 80, 10, 0, 33, 3.5, 1.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        macros::ATTACK(agent, 1, 0, Hash40::new("arml"), 2.5, 55, 10, 0, 33, 2.0, -1.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+    }
+    frame(agent.lua_state_agent, 9.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+    frame(agent.lua_state_agent, 13.0);
+    if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_COMBO);
+    }
+}
+
+unsafe extern "C" fn game_attack12(agent: &mut L2CAgentBase) {
+    frame(agent.lua_state_agent, 5.0);
+    if macros::is_excute(agent) {
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 2.0, 60, 20, 0, 50, 3.5, 0.0, 8.8, 5.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 2.0, 90, 20, 0, 50, 4.5, 0.0, 8.8, 9.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        macros::ATTACK(agent, 2, 0, Hash40::new("top"), 2.0, 45, 20, 0, 50, 2.8, 0.0, 8.8, 1.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+    }
+    wait(agent.lua_state_agent, 2.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+    frame(agent.lua_state_agent, 13.0);
+    if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_COMBO);
+    }
+}
+
+unsafe extern "C" fn game_attack13(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 9.0);
     if macros::is_excute(agent) {
         VarModule::on_flag(agent.module_accessor, fighter::status::flag::JUMP_CANCEL);
-        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 3.0, 70, 90, 0, 50, 5.5, 0.0, 8.0, 4.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
-        macros::ATTACK(agent, 1, 0, Hash40::new("footr"), 3.0, 70, 90, 0, 50, 3.5, 3.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 3.0, 70, 90, 0, 50, 5.5, 0.0, 8.0, 4.5, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        macros::ATTACK(agent, 1, 0, Hash40::new("footr"), 3.0, 70, 90, 0, 50, 3.5, 3.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
     }
     wait(agent.lua_state_agent, 2.0);
     macros::FT_MOTION_RATE(agent, 0.89);
@@ -119,6 +153,10 @@ unsafe extern "C" fn game_attacklw3(agent: &mut L2CAgentBase) {
 }
 
 pub fn install(agent: &mut smashline::Agent) {
+    agent.acmd("game_attack11", game_attack11);
+
+    agent.acmd("game_attack12", game_attack12);
+
     agent.acmd("game_attack13", game_attack13);
 
     agent.acmd("game_attackdash", game_attackdash);

--- a/src/fighter/lucario/acmd/specials.rs
+++ b/src/fighter/lucario/acmd/specials.rs
@@ -145,9 +145,13 @@ unsafe extern "C" fn game_specials(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         macros::CATCH(agent, 0, Hash40::new("top"), 3.0, 0.0, 6.0, 12.5, Some(0.0), Some(6.0), Some(6.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
     }
-    wait(agent.lua_state_agent, 1.0);
+    wait(agent.lua_state_agent, 6.0);
     if macros::is_excute(agent) {
         grab!(agent, *MA_MSC_CMD_GRAB_CLEAR_ALL);
+    }
+    frame(agent.lua_state_agent, 30.0);
+    if macros::is_excute(agent) {
+        VarModule::on_flag(agent.module_accessor, lucario::status::flag::SPECIAL_S_ENABLE_GRAVITY);
     }
 }
 
@@ -159,72 +163,12 @@ unsafe extern "C" fn effect_specials(agent: &mut L2CAgentBase) {
         macros::EFFECT_FOLLOW(agent, Hash40::new("lucario_hakkei_aura"), Hash40::new("haver"), 0, 0, 0.5, 0, 0, 0, 1, true);
         EffectModule::enable_sync_init_pos_last(agent.module_accessor);
     }
-}
-
-unsafe extern "C" fn sound_specials(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 7.0);
-    if macros::is_excute(agent) {
-        macros::PLAY_SE(agent, Hash40::new("se_lucario_special_s03"));
-    }
-}
-
-unsafe extern "C" fn expression_specials(agent: &mut L2CAgentBase) {
-    if macros::is_excute(agent) {
-        ItemModule::set_have_item_visibility(agent.module_accessor, false, 0);
-        slope!(agent, MA_MSC_CMD_SLOPE_SLOPE, SLOPE_STATUS_LR);
-    }
-    frame(agent.lua_state_agent, 40.0);
-    if macros::is_excute(agent) {
-        ItemModule::set_have_item_visibility(agent.module_accessor, true, 0);
-    }
-}
-
-unsafe extern "C" fn game_specials2(agent: &mut L2CAgentBase) {
-    if macros::is_excute(agent) {
-        FighterAreaModuleImpl::enable_fix_jostle_area(agent.module_accessor, 2.0, 5.0);
-        macros::ATTACK_ABS(agent, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 6.0, 361, 100, 0, 60, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
-    }
-    frame(agent.lua_state_agent, 8.0);
-    if macros::is_excute(agent) {
-        macros::CATCH(agent, 0, Hash40::new("top"), 3.0, 0.0, 6.0, 5.0, Some(0.0), Some(6.0), Some(2.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
-    }
-    wait(agent.lua_state_agent, 1.0);
-    if macros::is_excute(agent) {
-        macros::CATCH(agent, 0, Hash40::new("top"), 3.0, 0.0, 6.0, 7.0, Some(0.0), Some(6.0), Some(2.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
-    }
-    wait(agent.lua_state_agent, 1.0);
-    if macros::is_excute(agent) {
-        macros::CATCH(agent, 0, Hash40::new("top"), 3.0, 0.0, 6.0, 9.0, Some(0.0), Some(6.0), Some(4.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
-    }
-    wait(agent.lua_state_agent, 1.0);
-    if macros::is_excute(agent) {
-        macros::CATCH(agent, 0, Hash40::new("top"), 3.0, 0.0, 6.0, 11.5, Some(0.0), Some(6.0), Some(5.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
-    }
-    wait(agent.lua_state_agent, 1.0);
-    if macros::is_excute(agent) {
-        macros::CATCH(agent, 0, Hash40::new("top"), 3.0, 0.0, 6.0, 12.5, Some(0.0), Some(6.0), Some(6.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
-    }
-    wait(agent.lua_state_agent, 6.0);
-    if macros::is_excute(agent) {
-        grab!(agent, *MA_MSC_CMD_GRAB_CLEAR_ALL);
-    }
-    frame(agent.lua_state_agent, 30.0);
-    if macros::is_excute(agent) {
-        VarModule::on_flag(agent.module_accessor, lucario::status::flag::SPECIAL_S_ENABLE_GRAVITY);
-    }
-}
-
-unsafe extern "C" fn effect_specials2(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 6.0);
-    if macros::is_excute(agent) {
-        macros::EFFECT_FOLLOW(agent, Hash40::new("lucario_hakkei_aura"), Hash40::new("havel"), 0, 0, 0.5, 0, 0, 0, 1, true);
-        EffectModule::enable_sync_init_pos_last(agent.module_accessor);
-        macros::EFFECT_FOLLOW(agent, Hash40::new("lucario_hakkei_aura"), Hash40::new("haver"), 0, 0, 0.5, 0, 0, 0, 1, true);
-        EffectModule::enable_sync_init_pos_last(agent.module_accessor);
-    }
     frame(agent.lua_state_agent, 7.0);
     if macros::is_excute(agent) {
         macros::LANDING_EFFECT(agent, Hash40::new("sys_dash_smoke"), Hash40::new("top"), -4.5, 0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 0, 0, false);
+    }
+    if VarModule::is_flag(agent.module_accessor, lucario::status::flag::SPECIAL_S_ENHANCE) {
+        FGCModule::ex_flash(agent);
     }
     frame(agent.lua_state_agent, 8.0);
     for _ in 0..4 {
@@ -235,14 +179,19 @@ unsafe extern "C" fn effect_specials2(agent: &mut L2CAgentBase) {
     }
 }
 
-unsafe extern "C" fn sound_specials2(agent: &mut L2CAgentBase) {
+unsafe extern "C" fn sound_specials(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 7.0);
     if macros::is_excute(agent) {
         macros::PLAY_SE(agent, Hash40::new("se_lucario_special_s03"));
     }
+    if VarModule::is_flag(agent.module_accessor, lucario::status::flag::SPECIAL_S_ENHANCE) {
+        if macros::is_excute(agent) {
+            macros::PLAY_SE(agent, Hash40::new("se_common_waza_ex"));
+        }
+    }
 }
 
-unsafe extern "C" fn expression_specials2(agent: &mut L2CAgentBase) {
+unsafe extern "C" fn expression_specials(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         ItemModule::set_have_item_visibility(agent.module_accessor, false, 0);
         slope!(agent, MA_MSC_CMD_SLOPE_SLOPE, SLOPE_STATUS_LR);
@@ -286,9 +235,13 @@ unsafe extern "C" fn game_specialairs(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         macros::CATCH(agent, 0, Hash40::new("top"), 3.0, 0.0, 6.0, 12.5, Some(0.0), Some(6.0), Some(6.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
     }
-    wait(agent.lua_state_agent, 1.0);
+    wait(agent.lua_state_agent, 6.0);
     if macros::is_excute(agent) {
         grab!(agent, *MA_MSC_CMD_GRAB_CLEAR_ALL);
+    }
+    frame(agent.lua_state_agent, 20.0);
+    if macros::is_excute(agent) {
+        VarModule::on_flag(agent.module_accessor, lucario::status::flag::SPECIAL_S_ENABLE_GRAVITY);
     }
 }
 
@@ -300,68 +253,9 @@ unsafe extern "C" fn effect_specialairs(agent: &mut L2CAgentBase) {
         macros::EFFECT_FOLLOW(agent, Hash40::new("lucario_hakkei_aura"), Hash40::new("haver"), 0, 0, 0.5, 0, 0, 0, 1, true);
         EffectModule::enable_sync_init_pos_last(agent.module_accessor);
     }
-}
-
-unsafe extern "C" fn sound_specialairs(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 7.0);
-    if macros::is_excute(agent) {
-        macros::PLAY_SE(agent, Hash40::new("se_lucario_special_s03"));
-    }
-}
-
-unsafe extern "C" fn expression_specialairs(agent: &mut L2CAgentBase) {
-    if macros::is_excute(agent) {
-        ItemModule::set_have_item_visibility(agent.module_accessor, false, 0);
-        slope!(agent, MA_MSC_CMD_SLOPE_SLOPE, SLOPE_STATUS_LR);
-    }
-    frame(agent.lua_state_agent, 40.0);
-    if macros::is_excute(agent) {
-        ItemModule::set_have_item_visibility(agent.module_accessor, true, 0);
-    }
-}
-
-unsafe extern "C" fn game_specialairs2(agent: &mut L2CAgentBase) {
-    if macros::is_excute(agent) {
-        FighterAreaModuleImpl::enable_fix_jostle_area(agent.module_accessor, 9.0, 5.0);
-        macros::ATTACK_ABS(agent, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 6.0, 361, 100, 0, 60, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
-    }
-    frame(agent.lua_state_agent, 8.0);
-    if macros::is_excute(agent) {
-        macros::CATCH(agent, 0, Hash40::new("top"), 3.0, 0.0, 6.0, 5.0, Some(0.0), Some(6.0), Some(2.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
-    }
-    wait(agent.lua_state_agent, 1.0);
-    if macros::is_excute(agent) {
-        macros::CATCH(agent, 0, Hash40::new("top"), 3.0, 0.0, 6.0, 7.0, Some(0.0), Some(6.0), Some(2.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
-    }
-    wait(agent.lua_state_agent, 1.0);
-    if macros::is_excute(agent) {
-        macros::CATCH(agent, 0, Hash40::new("top"), 3.0, 0.0, 6.0, 9.0, Some(0.0), Some(6.0), Some(4.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
-    }
-    wait(agent.lua_state_agent, 1.0);
-    if macros::is_excute(agent) {
-        macros::CATCH(agent, 0, Hash40::new("top"), 3.0, 0.0, 6.0, 11.5, Some(0.0), Some(6.0), Some(5.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
-    }
-    wait(agent.lua_state_agent, 1.0);
-    if macros::is_excute(agent) {
-        macros::CATCH(agent, 0, Hash40::new("top"), 3.0, 0.0, 6.0, 12.5, Some(0.0), Some(6.0), Some(6.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
-    }
-    wait(agent.lua_state_agent, 6.0);
-    if macros::is_excute(agent) {
-        grab!(agent, *MA_MSC_CMD_GRAB_CLEAR_ALL);
-    }
-    frame(agent.lua_state_agent, 30.0);
-    if macros::is_excute(agent) {
-        VarModule::on_flag(agent.module_accessor, lucario::status::flag::SPECIAL_S_ENABLE_GRAVITY);
-    }
-}
-
-unsafe extern "C" fn effect_specialairs2(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 6.0);
-    if macros::is_excute(agent) {
-        macros::EFFECT_FOLLOW(agent, Hash40::new("lucario_hakkei_aura"), Hash40::new("havel"), 0, 0, 0.5, 0, 0, 0, 1, true);
-        EffectModule::enable_sync_init_pos_last(agent.module_accessor);
-        macros::EFFECT_FOLLOW(agent, Hash40::new("lucario_hakkei_aura"), Hash40::new("haver"), 0, 0, 0.5, 0, 0, 0, 1, true);
-        EffectModule::enable_sync_init_pos_last(agent.module_accessor);
+    if VarModule::is_flag(agent.module_accessor, lucario::status::flag::SPECIAL_S_ENHANCE) {
+        FGCModule::ex_flash(agent);
     }
     frame(agent.lua_state_agent, 8.0);
     for _ in 0..4 {
@@ -369,24 +263,6 @@ unsafe extern "C" fn effect_specialairs2(agent: &mut L2CAgentBase) {
             macros::EFFECT(agent, Hash40::new("sys_attack_speedline"), Hash40::new("top"), -0.0, 7.0, -3, 180, 0, 0, 1.2, 0, 0, 0, 0, 0, 0, true);
         }
         wait(agent.lua_state_agent, 2.0);
-    }
-}
-
-unsafe extern "C" fn sound_specialairs2(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 7.0);
-    if macros::is_excute(agent) {
-        macros::PLAY_SE(agent, Hash40::new("se_lucario_special_s03"));
-    }
-}
-
-unsafe extern "C" fn expression_specialairs2(agent: &mut L2CAgentBase) {
-    if macros::is_excute(agent) {
-        ItemModule::set_have_item_visibility(agent.module_accessor, false, 0);
-        slope!(agent, MA_MSC_CMD_SLOPE_SLOPE, SLOPE_STATUS_LR);
-    }
-    frame(agent.lua_state_agent, 48.0);
-    if macros::is_excute(agent) {
-        ItemModule::set_have_item_visibility(agent.module_accessor, true, 0);
     }
 }
 
@@ -493,7 +369,6 @@ unsafe extern "C" fn game_specialsthrow2(agent: &mut L2CAgentBase) {
     }
     frame(agent.lua_state_agent, 27.0);
     if macros::is_excute(agent) {
-        lucario_drain_aura(agent, false);
         let target = WorkModule::get_int64(agent.module_accessor, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT);
         let target_group = WorkModule::get_int64(agent.module_accessor, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP);
         let target_no = WorkModule::get_int64(agent.module_accessor, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO);
@@ -528,7 +403,6 @@ unsafe extern "C" fn effect_specialsthrow2(agent: &mut L2CAgentBase) {
         macros::LANDING_EFFECT(agent, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
     }
     frame(agent.lua_state_agent, 35.0);
-    FGCModule::ex_flash(agent);
     if macros::is_excute(agent) {
         macros::EFFECT_FLW_POS(agent, Hash40::new("lucario_hakkei_start"), Hash40::new("haver"), -0.9, 0, 0, 0, 0, 0, 1.5, true);
         macros::LAST_EFFECT_SET_RATE(agent, 0.25);
@@ -562,10 +436,6 @@ unsafe extern "C" fn sound_specialsthrow2(agent: &mut L2CAgentBase) {
             macros::PLAY_SE(agent, Hash40::new("se_lucario_special_s01"));
             macros::PLAY_SE(agent, Hash40::new("se_lucario_special_s02_l"));
         }
-    }
-    frame(agent.lua_state_agent, 35.0);
-    if macros::is_excute(agent) {
-        macros::PLAY_SE(agent, Hash40::new("se_common_waza_ex"));
     }
     frame(agent.lua_state_agent, 55.0);
     if macros::is_excute(agent) {
@@ -737,9 +607,6 @@ unsafe extern "C" fn effect_specialairsthrow2(agent: &mut L2CAgentBase) {
 }
 
 unsafe extern "C" fn sound_specialairsthrow2(agent: &mut L2CAgentBase) {
-    if macros::is_excute(agent) {
-        macros::PLAY_SE(agent, Hash40::new("se_common_waza_ex"));
-    }
     frame(agent.lua_state_agent, 23.0);
     if macros::is_excute(agent) {
         macros::PLAY_SE_REMAIN(agent, Hash40::new("vc_lucario_005"));
@@ -1200,20 +1067,10 @@ pub fn install(agent: &mut smashline::Agent) {
     agent.acmd("sound_specials", sound_specials);
     agent.acmd("expression_specials", expression_specials);
 
-    agent.acmd("game_specials2", game_specials2);
-    agent.acmd("effect_specials2", effect_specials2);
-    agent.acmd("sound_specials2", sound_specials2);
-    agent.acmd("expression_specials2", expression_specials2);
-
     agent.acmd("game_specialairs", game_specialairs);
     agent.acmd("effect_specialairs", effect_specialairs);
-    agent.acmd("sound_specialairs", sound_specialairs);
-    agent.acmd("expression_specialairs", expression_specialairs);
-
-    agent.acmd("game_specialairs2", game_specialairs2);
-    agent.acmd("effect_specialairs2", effect_specialairs2);
-    agent.acmd("sound_specialairs2", sound_specialairs2);
-    agent.acmd("expression_specialairs2", expression_specialairs2);
+    agent.acmd("sound_specialairs", sound_specials);
+    agent.acmd("expression_specialairs", expression_specials);
 
     agent.acmd("game_specialsthrow", game_specialsthrow);
     agent.acmd("effect_specialsthrow", effect_specialsthrow);

--- a/src/fighter/lucario/auraball/acmd/specials.rs
+++ b/src/fighter/lucario/auraball/acmd/specials.rs
@@ -19,8 +19,8 @@ unsafe extern "C" fn sound_charge(agent: &mut L2CAgentBase) {
 unsafe extern "C" fn game_shoot(agent: &mut L2CAgentBase) {
     if !VarModule::is_flag(agent.module_accessor, lucario_auraball::instance::flag::SPIRIT_BOMB) {
         if macros::is_excute(agent) {
-            macros::ATTACK(agent, 0, 0, Hash40::new("top"), 12.0, 361, 42, 0, 14, 2.2, 0.0, 0.0, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -2.3, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
-            macros::ATTACK(agent, 1, 0, Hash40::new("top"), 12.0, 361, 49, 0, 35, 2.2, 0.0, 0.0, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -2.3, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+            macros::ATTACK(agent, 0, 0, Hash40::new("top"), 10.0, 47, 69, 0, 40, 2.2, 0.0, 0.0, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -2.3, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+            macros::ATTACK(agent, 1, 0, Hash40::new("top"), 10.0, 47, 69, 0, 40, 2.2, 0.0, 0.0, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -2.3, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
             attack!(agent, MA_MSC_CMD_ATTACK_SET_LERP, 0, 1);
             AttackModule::enable_safe_pos(agent.module_accessor);
         }
@@ -85,7 +85,7 @@ unsafe extern "C" fn sound_shoot(agent: &mut L2CAgentBase) {
     }
 }
 
-unsafe extern "C" fn expression_explosion(agent: &mut L2CAgentBase) {
+unsafe extern "C" fn game_explosion(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         AttackModule::clear_all(agent.module_accessor);
         macros::ATTACK(agent, 0, 0, Hash40::new("top"), 12.0, 70, 70, 0, 80, 2.2, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, -2.3, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
@@ -111,6 +111,6 @@ pub fn install(agent: &mut smashline::Agent) {
     agent.acmd("game_shoot", game_shoot);
     agent.acmd("sound_shoot", sound_shoot);
 
-    agent.acmd("game_explosion", expression_explosion);
+    agent.acmd("game_explosion", game_explosion);
     agent.acmd("effect_explosion", effect_explosion);
 }

--- a/src/fighter/lucario/status/special_n.rs
+++ b/src/fighter/lucario/status/special_n.rs
@@ -80,8 +80,7 @@ unsafe extern "C" fn lucario_special_n_hold_main_loop(fighter: &mut L2CFighterCo
         return 0.into();
     }
     let max_charge_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("max_charge_frame"));
-    let charge = WorkModule::get_int(fighter.module_accessor, *FIGHTER_LUCARIO_INSTANCE_WORK_ID_INT_AURABALL_CHARGE_FRAME);
-    if charge >= max_charge_frame as i32 {
+    if fighter.global_table[STATUS_FRAME].get_f32() >= max_charge_frame + 4.0 {
         fighter.change_status(FIGHTER_LUCARIO_STATUS_KIND_SPECIAL_N_SHOOT.into(), false.into());
     }
     0.into()

--- a/src/fighter/lucario/status/special_s.rs
+++ b/src/fighter/lucario/status/special_s.rs
@@ -16,7 +16,7 @@ unsafe extern "C" fn lucario_special_s_set_kinetic(fighter: &mut L2CFighterCommo
     if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_GROUND {
         lucario_special_set_air(fighter);
         lucario_special_air_mot_helper(fighter);
-        if VarModule::is_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_ENHANCE) {
+        if VarModule::is_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_SET_MOTION) {
             if VarModule::is_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_POST_GRAVITY) {
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_FALL);
             }
@@ -45,18 +45,29 @@ unsafe extern "C" fn lucario_special_s_main_loop(fighter: &mut L2CFighterCommon)
     if !MotionModule::is_end(fighter.module_accessor) {
         if VarModule::is_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_CHECK_ENHANCE) {
             VarModule::off_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_CHECK_ENHANCE);
-            if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) {
-                WorkModule::set_int64(fighter.module_accessor, hash40("special_s2") as i64, *FIGHTER_LUCARIO_INSTANCE_WORK_ID_INT_GROUND_MOT);
-                WorkModule::set_int64(fighter.module_accessor, hash40("special_air_s2") as i64, *FIGHTER_LUCARIO_INSTANCE_WORK_ID_INT_AIR_MOT);
+            VarModule::on_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_SET_MOTION);
+            let enhance = VarModule::get_int(fighter.module_accessor, lucario::instance::int::AURA_LEVEL) > 0;
+            if enhance && ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) {
                 VarModule::on_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_ENHANCE);
-                lucario_special_s_set_kinetic(fighter);
+                lucario_drain_aura(fighter, false);
             }
+            lucario_special_s_set_kinetic(fighter);
         }
         if VarModule::is_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_ENABLE_GRAVITY) {
             VarModule::off_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_ENABLE_GRAVITY);
             VarModule::on_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_POST_GRAVITY);
             if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_AIR {
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_FALL);
+                sv_kinetic_energy!(
+                    controller_set_accel_x_add,
+                    fighter,
+                    0.02
+                );
+                sv_kinetic_energy!(
+                    controller_set_accel_x_mul,
+                    fighter,
+                    0.02
+                );
             }
         }
         if !StatusModule::is_changing(fighter.module_accessor)
@@ -77,7 +88,7 @@ unsafe extern "C" fn lucario_special_s_main_loop(fighter: &mut L2CFighterCommon)
 }
 
 unsafe extern "C" fn lucario_special_s_end(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if VarModule::is_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_ENHANCE) {
+    // if VarModule::is_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_ENHANCE) {
         fighter.clear_lua_stack();
         lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_MOTION);
         let speed_x = sv_kinetic_energy::get_speed_x(fighter.lua_state_agent);
@@ -89,7 +100,7 @@ unsafe extern "C" fn lucario_special_s_end(fighter: &mut L2CFighterCommon) -> L2
             speed_x * mul,
             0.0
         );
-    }
+    // }
     if fighter.global_table[STATUS_KIND].get_i32() == *FIGHTER_LUCARIO_STATUS_KIND_SPECIAL_S_THROW {
         VarModule::off_flag(fighter.module_accessor, fighter::instance::flag::DISABLE_SPECIAL_S);
     }
@@ -100,10 +111,9 @@ unsafe extern "C" fn lucario_special_s_throw_main(fighter: &mut L2CFighterCommon
     WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LUCARIO_INSTANCE_WORK_ID_FLAG_MOT_INHERIT);
     VarModule::off_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_ENABLE_GRAVITY);
     VarModule::off_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_POST_GRAVITY);
-    let enhance = VarModule::get_int(fighter.module_accessor, lucario::instance::int::AURA_LEVEL) > 0;
     let mot_g;
     let mot_a;
-    if enhance && ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) {
+    if VarModule::is_flag(fighter.module_accessor, lucario::status::flag::SPECIAL_S_ENHANCE) {
         mot_g = hash40("special_s_throw_2");
         mot_a = hash40("special_air_s_throw_2");
     }


### PR DESCRIPTION
# Changelog

## Jab
Reverted to Smash 4 hitboxes and framedata

## Aura Sphere (Neutral Special)
Aura Sphere logic adjusted (Kirby now matches Lucario).
Normal Aura Sphere adjusted:
- Life reduced (60 > 48)
- Speed reduced (2.5 > 2)

## Force Palm (Side Special)
Now always performs the dashing grab variant.
The EX Throw check is now attached to the beginning of the move.
Momentum is now retained in the air when the grab ends.

## Extreme Speed (Up Special)
Distance traveled reduced.
Distance gained from aura reduced.