### PR TITLE
Shield Adjustments

### DIFF
--- a/src/fighter/common/status/guard/guard.rs
+++ b/src/fighter/common/status/guard/guard.rs
@@ -284,6 +284,12 @@ unsafe extern "C" fn fighterstatusguard__set_shield_scale(fighter: &mut L2CFight
     0.into()
 }
 
+#[skyline::hook(replace = L2CFighterCommon_FighterStatusGuard__check_hit_stop_delay_flick)]
+unsafe extern "C" fn fighterstatusguard__check_hit_stop_delay_flick(_fighter: &mut L2CFighterCommon, _param_1: L2CValue) -> L2CValue {
+    // disable shield sdi
+    false.into()
+}
+
 fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hooks!(
@@ -294,7 +300,8 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
             check_guard_attack_special_hi,
             sub_ftstatusuniqprocessguardfunc_updateshield,
             bind_address_call_fighterstatusguard__set_shield_scale,
-            fighterstatusguard__set_shield_scale
+            fighterstatusguard__set_shield_scale,
+            fighterstatusguard__check_hit_stop_delay_flick
         );
     }
 }

--- a/src/fighter/common/status/guard/guard_damage.rs
+++ b/src/fighter/common/status/guard/guard_damage.rs
@@ -304,8 +304,8 @@ unsafe extern "C" fn status_guarddamage_common(fighter: &mut L2CFighterCommon, p
         WorkModule::set_int(fighter.module_accessor, 0, *FIGHTER_INSTANCE_WORK_ID_INT_DISABLE_ESCAPE_FRAME);
         HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_HIT_XLU);
-        let just_shield_precede_extension = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("just_shield_precede_extension"));
-        ControlModule::set_command_life_extend(fighter.module_accessor, just_shield_precede_extension as u8);
+        // let just_shield_precede_extension = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("just_shield_precede_extension"));
+        // ControlModule::set_command_life_extend(fighter.module_accessor, just_shield_precede_extension as u8);
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x20cbc92683), 1, FIGHTER_LOG_DATA_INT_JUST_SHIELD);
         let boma = fighter.global_table[MODULE_ACCESSOR].get_ptr() as *mut BattleObjectModuleAccessor;
         FighterUtil::flash_eye_info(boma);


### PR DESCRIPTION
# Changelog

Removes the 3 extra frames of advantage on Parry. The advantage is now the intangibility granted on parry.
Removes shield SDI.
Removes the buffer extension on Parry. This doesn't matter due to an earlier change made that fully buffers actions during hitstop.