### PR TITLE
Ledge Trump Logic Reversal

### DIFF
--- a/src/fighter/common/status/cliff.rs
+++ b/src/fighter/common/status/cliff.rs
@@ -40,6 +40,12 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
     }
 }
 
+#[skyline::hook(offset = 0x617aa4, inline)]
+unsafe extern "C" fn reverse_trump_logic(ctx: &mut skyline::hooks::InlineCtx) {
+    let object = *ctx.registers[23].x.as_ref() as *mut BattleObject;
+    WorkModule::on_flag((*object).module_accessor, *FIGHTER_STATUS_CLIFF_FLAG_TO_ROB);
+}
+
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
     cliff_catch::install();
@@ -48,4 +54,11 @@ pub fn install() {
 
     cliff_jump1::install();
     cliff_jump2::install();
+
+    skyline::patching::Patch::in_text(0x617a90).nop();
+    skyline::patching::Patch::in_text(0x617aa4).nop();
+    skyline::install_hooks!(
+        reverse_trump_logic
+    );
+
 }


### PR DESCRIPTION
# Changelog

Flips the logic for Ledge Trumping so that instead of the first player to grab ledge being forced off, any player after the first to grab the ledge gets forced off instead.

Players can still buffer ledge options to avoid getting trumped.