### PR TITLE
Remove Max Charge Flashing

### DIFF
--- a/fighters/common/src/effect.rs
+++ b/fighters/common/src/effect.rs
@@ -1,0 +1,23 @@
+// use super::*;
+
+extern "C" {
+    #[link_name = "_ZN7lua2cpp29L2CFighterAnimcmdEffectCommon31bind_hash_call_effect_ChargeMaxEPN3lib8L2CAgentERNS1_7utility8VariadicEPKcSt9__va_list"]
+    fn bind_hash_call_effect_ChargeMax();
+}
+
+#[skyline::hook(replace = bind_hash_call_effect_ChargeMax)]
+unsafe extern "C" fn effect_chargemax() {
+    // nothing
+}
+
+fn nro_hook(info: &skyline::nro::NroInfo) {
+    if info.name == "common" {
+        skyline::install_hooks!(
+            effect_chargemax
+        );
+    }
+}
+
+pub fn install() {
+    skyline::nro::add_hook(nro_hook);
+}

--- a/fighters/common/src/lib.rs
+++ b/fighters/common/src/lib.rs
@@ -22,10 +22,12 @@ pub mod frame;
 pub mod status;
 pub mod agent_inits;
 pub mod param;
+mod effect;
 // pub mod command_inputs;
 mod energy;
 
 pub fn install() {
     status::install();
     energy::install();
+    effect::install();
 }


### PR DESCRIPTION
# Changelog

Removes the effect that occurs when a character fully charges a store-able special move.

This effect overlaps with the invincibility/intangibility flashing effect.