### PR TITLE
Command Input Shenanigans

### DIFF
--- a/WuBor-Utils/src/app.rs
+++ b/WuBor-Utils/src/app.rs
@@ -226,6 +226,36 @@ impl ShieldGroupResource2 {
     }
 }
 
+pub mod Cat4 {
+    pub const SPECIAL_N_COMMAND : usize = 0x0;
+    pub const SPECIAL_N2_COMMAND : usize = 0x1;
+    pub const SPECIAL_S_COMMAND : usize = 0x2;
+    pub const SPECIAL_HI_COMMAND : usize = 0x3;
+    pub const COMMAND_6N6 : usize = 0x4;
+    pub const COMMAND_4N4 : usize = 0x5;
+    pub const ATTACK_COMMAND1 : usize = 0x6;
+    pub const SPECIAL_HI2_COMMAND : usize = 0x7;
+    pub const SUPER_SPECIAL_COMMAND : usize = 0x8;
+    pub const SUPER_SPECIAL_R_COMMAND : usize = 0x9;
+    pub const SUPER_SPECIAL2_COMMAND : usize = 0xA;
+    pub const SUPER_SPECIAL2_R_COMMAND : usize = 0xB;
+    pub const COMMAND_623NB : usize = 0xC;
+    pub const COMMAND_623STRICT : usize = 0xD;
+    pub const COMMAND_623ALONG : usize = 0xE;
+    pub const COMMAND_623BLONG : usize = 0xF;
+    pub const COMMAND_623A : usize = 0x10;
+    pub const COMMAND_2 : usize = 0x11;
+    pub const COMMAND_3 : usize = 0x12;
+    pub const COMMAND_1 : usize = 0x13;
+    pub const COMMAND_6 : usize = 0x14;
+    pub const COMMAND_4 : usize = 0x15;
+    pub const COMMAND_8 : usize = 0x16;
+    pub const COMMAND_9 : usize = 0x17;
+    pub const COMMAND_7 : usize = 0x18;
+    pub const COMMAND_6N6AB : usize = 0x19;
+    pub const COMMAND_323CATCH : usize = 0x1A;
+}
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CommandInputState {

--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -266,8 +266,13 @@ pub mod dolly {
             pub const SPECIAL_LW_BREAK : i32 = 0x1152;
         }
         pub mod int {
+            pub const ATTACK_DASH_STRENGTH : i32 = 0x1150;
+
             pub const D_TILT_CHAIN_COUNT : i32 = 0x1150;
         }
+
+        pub const ATTACK_DASH_COMMAND : i32 = 0x203;
+        pub const SPECIAL_N_COMMAND : i32 = 0x204;
     }
 }
 
@@ -392,6 +397,8 @@ pub mod kirby {
         pub mod int {
             pub const APPEAL_S_LOOP_COUNT : i32 = 0x1150;
         }
+
+        pub const DOLLY_SPECIAL_N_COMMAND : i32 = 0x37D;
     }
 }
 

--- a/WuBor-Utils/src/wua_bind.rs
+++ b/WuBor-Utils/src/wua_bind.rs
@@ -432,6 +432,14 @@ pub mod FGCModule {
         let command_input = *control_module.add((0x7f0 + (command * 8)) / 8) as *mut u8;
         *command_input.add(0xb) = buttons;
     }
+
+    /// Clones a command input to another cat4 flag
+    pub unsafe fn clone_command_input(module_accessor: *mut BattleObjectModuleAccessor, command: usize, replace_command: usize) {
+        let control_module = *(module_accessor as *const *const u64).add(0x48 / 8);
+        let original = *control_module.add((0x7f0 + (command * 8)) / 8) as *mut CommandInputState;
+        let replace = *control_module.add((0x7f0 + (replace_command * 8)) / 8) as *mut CommandInputState;
+        *replace = *original.clone();
+    }
 }
 
 #[allow(non_snake_case)]

--- a/fighters/dolly/src/acmd/normals.rs
+++ b/fighters/dolly/src/acmd/normals.rs
@@ -113,16 +113,6 @@ unsafe extern "C" fn game_attack13(agent: &mut L2CAgentBase) {
 }
 
 unsafe extern "C" fn game_attackdash(agent: &mut L2CAgentBase) {
-    if macros::is_excute(agent) {
-        WorkModule::on_flag(agent.module_accessor, *FIGHTER_DOLLY_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
-        if !VarModule::is_flag(agent.module_accessor, vars::dolly::status::flag::ATTACK_DASH_COMMAND) {
-            WorkModule::on_flag(agent.module_accessor, *FIGHTER_DOLLY_STATUS_ATTACK_WORK_FLAG_HIT_CANCEL);
-            macros::FT_MOTION_RATE(agent, 0.8);
-        }
-        else {
-            macros::FT_MOTION_RATE(agent, 1.5);
-        }
-    }
     if VarModule::is_flag(agent.module_accessor, vars::dolly::instance::flag::RISING_FORCE) {
         if macros::is_excute(agent) {
             VarModule::on_flag(agent.module_accessor, vars::dolly::status::flag::DISABLE_METER_GAIN);
@@ -130,10 +120,34 @@ unsafe extern "C" fn game_attackdash(agent: &mut L2CAgentBase) {
             macros::WHOLE_HIT(agent, *HIT_STATUS_XLU);
         }
     }
+    frame(agent.lua_state_agent, 5.0);
+    if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_DOLLY_STATUS_SPECIAL_COMMON_WORK_FLAG_DECIDE_STRENGTH);
+    }
+    if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_DOLLY_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_DOLLY_STATUS_ATTACK_WORK_FLAG_HIT_CANCEL);
+    }
+    if VarModule::is_flag(agent.module_accessor, vars::dolly::instance::flag::RISING_FORCE) {
+        macros::FT_MOTION_RATE(agent, 2.0);
+    }
+    else if VarModule::get_int(agent.module_accessor, vars::dolly::status::int::ATTACK_DASH_STRENGTH) == *FIGHTER_DOLLY_STRENGTH_W {
+        macros::FT_MOTION_RATE(agent, 3.0 / 5.0);
+    }
+    else {
+        let attack_dash_h_distance_mul = WorkModule::get_param_float(agent.module_accessor, hash40("param_misc"), hash40("attack_dash_h_distance_mul"));
+        sv_kinetic_energy!(
+            set_speed_mul,
+            agent,
+            FIGHTER_KINETIC_ENERGY_ID_MOTION,
+            attack_dash_h_distance_mul
+        );
+        macros::FT_MOTION_RATE(agent, 2.0);
+    }
     frame(agent.lua_state_agent, 10.0);
     macros::FT_MOTION_RATE(agent, 1.0);
     if !VarModule::is_flag(agent.module_accessor, vars::dolly::instance::flag::RISING_FORCE) {
-        if !VarModule::is_flag(agent.module_accessor, vars::dolly::status::flag::ATTACK_DASH_COMMAND) {
+        if VarModule::get_int(agent.module_accessor, vars::dolly::status::int::ATTACK_DASH_STRENGTH) == *FIGHTER_DOLLY_STRENGTH_W {
             if macros::is_excute(agent) {
                 macros::ATTACK(agent, 0, 0, Hash40::new("top"), 8.0, 40, 30, 0, 75, 5.0, 0.0, 10.0, 3.0, Some(0.0), Some(6.0), Some(3.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_DOLLY_KICK, *ATTACK_REGION_BODY);
             }
@@ -154,7 +168,7 @@ unsafe extern "C" fn game_attackdash(agent: &mut L2CAgentBase) {
     }
     wait(agent.lua_state_agent, 5.0);
     if !VarModule::is_flag(agent.module_accessor, vars::dolly::instance::flag::RISING_FORCE) {
-        if !VarModule::is_flag(agent.module_accessor, vars::dolly::status::flag::ATTACK_DASH_COMMAND) {
+        if VarModule::get_int(agent.module_accessor, vars::dolly::status::int::ATTACK_DASH_STRENGTH) == *FIGHTER_DOLLY_STRENGTH_W {
             if macros::is_excute(agent) {
                 macros::ATTACK(agent, 0, 0, Hash40::new("top"), 5.0, 60, 30, 0, 30, 4.0, 0.0, 10.0, 4.0, Some(0.0), Some(6.0), Some(4.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_DOLLY_KICK, *ATTACK_REGION_BODY);
             }
@@ -171,7 +185,7 @@ unsafe extern "C" fn game_attackdash(agent: &mut L2CAgentBase) {
         JostleModule::set_status(agent.module_accessor, true);
         AttackModule::clear_all(agent.module_accessor);
     }
-    if !VarModule::is_flag(agent.module_accessor, vars::dolly::status::flag::ATTACK_DASH_COMMAND) {
+    if VarModule::get_int(agent.module_accessor, vars::dolly::status::int::ATTACK_DASH_STRENGTH) == *FIGHTER_DOLLY_STRENGTH_W {
         macros::FT_MOTION_RATE(agent, 1.5);
     }
     else {

--- a/fighters/dolly/src/agent_init.rs
+++ b/fighters/dolly/src/agent_init.rs
@@ -234,7 +234,7 @@ unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {
     fighter.global_table[STATUS_END_CONTROL].assign(&L2CValue::Ptr(dolly_status_end_control as *const () as _));
     // fighter.global_table[STATUS_END_CONTROL].assign(&L2CValue::Bool(false));
     FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_N_COMMAND, 1);
-    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_N2_COMMAND, 2);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_N2_COMMAND, 1);
     FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_S_COMMAND, 1);
     FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_HI_COMMAND, 2);
 

--- a/fighters/dolly/src/agent_init.rs
+++ b/fighters/dolly/src/agent_init.rs
@@ -234,20 +234,19 @@ unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {
     fighter.global_table[CHECK_GROUND_CATCH_UNIQ].assign(&L2CValue::Ptr(dolly_check_ground_catch_pre as *const () as _));
     fighter.global_table[STATUS_END_CONTROL].assign(&L2CValue::Ptr(dolly_status_end_control as *const () as _));
     // fighter.global_table[STATUS_END_CONTROL].assign(&L2CValue::Bool(false));
-    FGCModule::set_command_input_button(fighter.module_accessor, 0, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 1, 1);
-    FGCModule::set_command_input_button(fighter.module_accessor, 2, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 3, 2);
-    let control_module = *(fighter.module_accessor as *const *const u64).add(0x48 / 8);
-    let special_s_command = *control_module.add((0x7f0 + (2 * 8)) / 8) as *mut CommandInputState;
-    let attack_command = *control_module.add((0x7f0 + (6 * 8)) / 8) as *mut CommandInputState;
-    *attack_command = *special_s_command.clone();
-    FGCModule::set_command_input_button(fighter.module_accessor, 6, 1);
-    FGCModule::set_command_input_button(fighter.module_accessor, 7, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 8, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 9, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 10, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, 11, 2);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_N_COMMAND, 2);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_N2_COMMAND, 1);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_S_COMMAND, 2);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_HI_COMMAND, 2);
+
+    FGCModule::clone_command_input(fighter.module_accessor, Cat4::SPECIAL_S_COMMAND, Cat4::ATTACK_COMMAND1);
+
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::ATTACK_COMMAND1, 1);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_HI2_COMMAND, 2);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL_COMMAND, 2);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL_R_COMMAND, 2);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL2_COMMAND, 2);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL2_R_COMMAND, 2);
 }
 
 pub fn install(agent: &mut Agent) {

--- a/fighters/dolly/src/agent_init.rs
+++ b/fighters/dolly/src/agent_init.rs
@@ -233,17 +233,17 @@ unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {
     fighter.global_table[CHECK_GROUND_CATCH_UNIQ].assign(&L2CValue::Ptr(dolly_check_ground_catch_pre as *const () as _));
     fighter.global_table[STATUS_END_CONTROL].assign(&L2CValue::Ptr(dolly_status_end_control as *const () as _));
     // fighter.global_table[STATUS_END_CONTROL].assign(&L2CValue::Bool(false));
-    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_N_COMMAND, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_N2_COMMAND, 1);
-    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_S_COMMAND, 2);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_N_COMMAND, 1);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_N2_COMMAND, 2);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_S_COMMAND, 1);
     FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_HI_COMMAND, 2);
 
     FGCModule::clone_command_input(fighter.module_accessor, Cat4::SPECIAL_S_COMMAND, Cat4::ATTACK_COMMAND1);
 
-    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::ATTACK_COMMAND1, 1);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::ATTACK_COMMAND1, 2);
     FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_HI2_COMMAND, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL_COMMAND, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL_R_COMMAND, 2);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL_COMMAND, 1);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL_R_COMMAND, 1);
     FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL2_COMMAND, 2);
     FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL2_R_COMMAND, 2);
 }

--- a/fighters/dolly/src/agent_init.rs
+++ b/fighters/dolly/src/agent_init.rs
@@ -241,7 +241,7 @@ unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {
     FGCModule::clone_command_input(fighter.module_accessor, Cat4::SPECIAL_S_COMMAND, Cat4::ATTACK_COMMAND1);
 
     FGCModule::set_command_input_button(fighter.module_accessor, Cat4::ATTACK_COMMAND1, 2);
-    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_HI2_COMMAND, 2);
+    FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SPECIAL_HI2_COMMAND, 1);
     FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL_COMMAND, 1);
     FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL_R_COMMAND, 1);
     FGCModule::set_command_input_button(fighter.module_accessor, Cat4::SUPER_SPECIAL2_COMMAND, 2);

--- a/fighters/dolly/src/agent_init.rs
+++ b/fighters/dolly/src/agent_init.rs
@@ -47,7 +47,8 @@ pub unsafe extern "C" fn dolly_check_special_command(fighter: &mut L2CFighterCom
         return true.into();
     }
 
-    if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
+    if !fighter.global_table[IS_STOP].get_bool()
+    && cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND)
     && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[CHECK_SPECIAL_N_UNIQ].clone()).get_bool() {
         fighter.change_status(vars::dolly::status::SPECIAL_N_COMMAND.into(), true.into());

--- a/fighters/dolly/src/agent_init.rs
+++ b/fighters/dolly/src/agent_init.rs
@@ -29,8 +29,7 @@ pub unsafe extern "C" fn dolly_check_special_command(fighter: &mut L2CFighterCom
     if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
     && cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N2_COMMAND != 0
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N2_COMMAND) {
-        VarModule::on_flag(fighter.module_accessor, vars::dolly::status::flag::ATTACK_DASH_COMMAND);
-        fighter.change_status(FIGHTER_STATUS_KIND_ATTACK_DASH.into(), true.into());
+        fighter.change_status(vars::dolly::status::ATTACK_DASH_COMMAND.into(), true.into());
         return true.into();
     }
 
@@ -51,7 +50,7 @@ pub unsafe extern "C" fn dolly_check_special_command(fighter: &mut L2CFighterCom
     if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND)
     && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[CHECK_SPECIAL_N_UNIQ].clone()).get_bool() {
-        fighter.change_status(FIGHTER_STATUS_KIND_SPECIAL_N.into(), true.into());
+        fighter.change_status(vars::dolly::status::SPECIAL_N_COMMAND.into(), true.into());
         return true.into();
     }
 

--- a/fighters/dolly/src/frame.rs
+++ b/fighters/dolly/src/frame.rs
@@ -76,6 +76,7 @@ unsafe extern "C" fn dolly_super_special_aura(fighter: &mut L2CFighterCommon) {
 unsafe extern "C" fn dolly_super_super_cancels(fighter: &mut L2CFighterCommon) {
     let status = fighter.global_table[STATUS_KIND].get_i32();
     if status == *FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL2_BLOW
+    && !fighter.global_table[IS_STOP].get_bool()
     && fighter.global_table[STATUS_FRAME].get_f32() < 8.0 {
         WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N2_COMMAND);
         if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_DOLLY_INSTANCE_WORK_ID_FLAG_ENABLE_SUPER_SPECIAL) {

--- a/fighters/dolly/src/helper.rs
+++ b/fighters/dolly/src/helper.rs
@@ -64,7 +64,8 @@ pub unsafe extern "C" fn dolly_special_cancel(fighter: &mut L2CFighterCommon, si
     for val in terms.iter() {
         WorkModule::enable_transition_term(fighter.module_accessor, *val);
     }
-    if fighter.global_table[STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_ATTACK_DASH {
+    if fighter.global_table[STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_ATTACK_DASH
+    || fighter.global_table[STATUS_KIND].get_i32() == vars::dolly::status::ATTACK_DASH_COMMAND {
         WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N);
         WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_S);
         WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND);
@@ -80,7 +81,7 @@ pub unsafe extern "C" fn dolly_special_cancel(fighter: &mut L2CFighterCommon, si
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW_COMMAND);
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI);
         }
-        else if VarModule::is_flag(fighter.module_accessor, vars::dolly::status::flag::ATTACK_DASH_COMMAND) {
+        else if VarModule::get_int(fighter.module_accessor, vars::dolly::status::int::ATTACK_DASH_STRENGTH) == *FIGHTER_DOLLY_STRENGTH_W {
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW);
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW_COMMAND);
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI);
@@ -111,7 +112,8 @@ pub unsafe extern "C" fn dolly_final_cancel(fighter: &mut L2CFighterCommon, situ
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_FINAL);
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL);
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL2);
-    if fighter.global_table[STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_ATTACK_DASH {
+    if fighter.global_table[STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_ATTACK_DASH
+    || fighter.global_table[STATUS_KIND].get_i32() == vars::dolly::status::ATTACK_DASH_COMMAND {
         if VarModule::is_flag(fighter.module_accessor, vars::dolly::instance::flag::RISING_FORCE) {
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL);
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL2);

--- a/fighters/dolly/src/helper.rs
+++ b/fighters/dolly/src/helper.rs
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn dolly_special_cancel(fighter: &mut L2CFighterCommon, si
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW_COMMAND);
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI);
         }
-        else if VarModule::get_int(fighter.module_accessor, vars::dolly::status::int::ATTACK_DASH_STRENGTH) == *FIGHTER_DOLLY_STRENGTH_W {
+        else if VarModule::get_int(fighter.module_accessor, vars::dolly::status::int::ATTACK_DASH_STRENGTH) == *FIGHTER_DOLLY_STRENGTH_S {
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW);
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW_COMMAND);
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI);

--- a/fighters/dolly/src/status/special_hi.rs
+++ b/fighters/dolly/src/status/special_hi.rs
@@ -230,8 +230,7 @@ unsafe extern "C" fn dolly_special_hi_set_kinetic(fighter: &mut L2CFighterCommon
 unsafe extern "C" fn dolly_special_hi_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
     // <WuBor>
     let situation = fighter.global_table[SITUATION_KIND].get_i32();
-    if !VarModule::is_flag(fighter.module_accessor, vars::dolly::instance::flag::RISING_FORCE)
-    && WorkModule::is_flag(fighter.module_accessor, *FIGHTER_DOLLY_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL)
+    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_DOLLY_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL)
     && AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_SHIELD | *COLLISION_KIND_MASK_HIT)
     && dolly_final_cancel(fighter, situation.into()).get_bool() {
         return 1.into();

--- a/fighters/dolly/src/status/special_n.rs
+++ b/fighters/dolly/src/status/special_n.rs
@@ -1,6 +1,15 @@
 use super::*;
 use crate::helper::*;
 
+unsafe extern "C" fn dolly_special_n_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    smashline::original_status(Pre, fighter, *FIGHTER_STATUS_KIND_SPECIAL_N)(fighter)
+}
+
+unsafe extern "C" fn dolly_special_n_command_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_DOLLY_STATUS_SPECIAL_COMMON_WORK_FLAG_COMMAND);
+    dolly_special_n_main(fighter)
+}
+
 unsafe extern "C" fn dolly_special_n_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     if VarModule::is_flag(fighter.module_accessor, vars::dolly::instance::flag::SPECIAL_CANCEL) {
         VarModule::on_flag(fighter.module_accessor, vars::dolly::status::flag::IS_SPECIAL_CANCEL);
@@ -126,4 +135,8 @@ unsafe extern "C" fn dolly_special_n_end(fighter: &mut L2CFighterCommon) -> L2CV
 pub fn install(agent: &mut Agent) {
     agent.status(Main, *FIGHTER_STATUS_KIND_SPECIAL_N, dolly_special_n_main);
     agent.status(End, *FIGHTER_STATUS_KIND_SPECIAL_N, dolly_special_n_end);
+
+    agent.status(Pre, vars::dolly::status::SPECIAL_N_COMMAND, dolly_special_n_pre);
+    agent.status(Main, vars::dolly::status::SPECIAL_N_COMMAND, dolly_special_n_command_main);
+    agent.status(End, vars::dolly::status::SPECIAL_N_COMMAND, dolly_special_n_end);
 }

--- a/fighters/dolly/src/status/superspecial.rs
+++ b/fighters/dolly/src/status/superspecial.rs
@@ -64,7 +64,7 @@ unsafe extern "C" fn dolly_super_special2_blow_end(fighter: &mut L2CFighterCommo
         CatchModule::catch_cut(fighter.module_accessor, false, false);
     }
     if ![
-        *FIGHTER_STATUS_KIND_ATTACK_DASH
+        vars::dolly::status::ATTACK_DASH_COMMAND
     ].contains(&status) {
         VarModule::off_flag(fighter.module_accessor, vars::dolly::instance::flag::RISING_FORCE);
         EffectModule::clear_screen(fighter.module_accessor, 1, 0x14);

--- a/fighters/ken/src/agent_init.rs
+++ b/fighters/ken/src/agent_init.rs
@@ -19,6 +19,13 @@ pub unsafe extern "C" fn ken_check_special_command(fighter: &mut L2CFighterCommo
         fighter.change_status(FIGHTER_RYU_STATUS_KIND_SPECIAL_HI_COMMAND.into(), true.into());
         return true.into();
     }
+    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
+    && cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_ATTACK_COMMAND1 != 0
+    && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_COMMAND1)
+    && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[CHECK_SPECIAL_S_UNIQ].clone()).get_bool() {
+        fighter.change_status(FIGHTER_RYU_STATUS_KIND_ATTACK_COMMAND1.into(), true.into());
+        return true.into();
+    }
     if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND)
     && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[CHECK_SPECIAL_N_UNIQ].clone()).get_bool() {

--- a/fighters/ken/src/status.rs
+++ b/fighters/ken/src/status.rs
@@ -7,6 +7,8 @@ mod attack;
 mod attack_lw4_start;
 mod attack_lw4;
 
+mod attack_command1;
+
 mod special_n2;
 
 mod special_s;
@@ -24,6 +26,8 @@ pub fn install(agent: &mut Agent) {
 
     attack_lw4_start::install(agent);
     attack_lw4::install(agent);
+
+    attack_command1::install(agent);
 
     special_n2::install(agent);
 

--- a/fighters/ken/src/status/attack_command1.rs
+++ b/fighters/ken/src/status/attack_command1.rs
@@ -1,0 +1,183 @@
+use super::*;
+
+extern "C" {
+    #[link_name = "ryu_final_hit_cancel"]
+    pub fn ryu_final_hit_cancel(fighter: &mut L2CFighterCommon, situation: L2CValue) -> L2CValue;
+}
+
+unsafe extern "C" fn ken_attack_command1_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let attr = if VarModule::is_flag(fighter.module_accessor, vars::ken::instance::flag::QUICK_STEP_INHERIT) {
+        0
+    }
+    else {
+        *FIGHTER_STATUS_ATTR_START_TURN
+    };
+
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_GROUND),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_KEEP as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        (
+            *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK |
+            *FIGHTER_LOG_MASK_FLAG_ACTION_TRIGGER_ON |
+            *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_ATTACK_COMMAND1
+        ) as u64,
+        attr as u32,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_N as u32,
+        0
+    );
+    0.into()
+}
+
+unsafe extern "C" fn ken_attack_command1_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_COMMON_FLAG_COMMAND);
+    GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND_CLIFF_STOP));
+    KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION);
+    0.into()
+}
+
+unsafe extern "C" fn ken_attack_command1_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    VarModule::set_int64(fighter.module_accessor, vars::ken::status::int64::SPECIAL_N2_GROUND_BRANCH_MOTION, hash40("invalid"));
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("special_n2_start"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+    if !StopModule::is_stop(fighter.module_accessor) {
+        ken_attack_command1_substatus(fighter, false.into());
+    }
+    fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(ken_attack_command1_substatus as *const () as _));
+    fighter.sub_shift_status_main(L2CValue::Ptr(ken_attack_command1_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn ken_attack_command1_substatus(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
+    if param_1.get_bool() {
+        WorkModule::inc_int(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_COMMON_INT_BUTTON_ON_TIMER);
+    }
+    if VarModule::is_flag(fighter.module_accessor, vars::ken::status::flag::SPECIAL_N2_GROUND_BRANCH_CHECK) {
+        if ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_ATTACK) {
+            let stick_x = fighter.global_table[STICK_X].get_f32();
+            let lr = PostureModule::lr(fighter.module_accessor);
+            let stick_y = fighter.global_table[STICK_Y].get_f32();
+            let squat_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("squat_stick_y"));
+            let mot = if stick_y > squat_stick_y.abs() {
+                hash40("special_n2_hi")
+            }
+            else if stick_y < squat_stick_y {
+                hash40("special_n2_lw")
+            }
+            else if stick_x * lr > squat_stick_y.abs() {
+                hash40("special_n2_s")
+            }
+            else {
+                hash40("invalid")
+            };
+            if mot != hash40("invalid") {
+                VarModule::set_int64(fighter.module_accessor, vars::ken::status::int64::SPECIAL_N2_GROUND_BRANCH_MOTION, mot);
+                VarModule::off_flag(fighter.module_accessor, vars::ken::status::flag::SPECIAL_N2_GROUND_BRANCH_CHECK);
+            }
+        }
+    }
+    0.into()
+}
+
+unsafe extern "C" fn ken_attack_command1_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if CancelModule::is_enable_cancel(fighter.module_accessor) {
+        if fighter.sub_wait_ground_check_common(false.into()).get_bool() {
+            return 1.into();
+        }
+    }
+    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL)
+    && AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_SHIELD | *COLLISION_KIND_MASK_HIT) {
+        let sitation = fighter.global_table[SITUATION_KIND].get_i32();
+        if ryu_final_hit_cancel(fighter, sitation.into()).get_bool() {
+            return 1.into();
+        }
+    }
+
+    if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_GROUND {
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+        return 0.into();
+    }
+
+    if VarModule::is_flag(fighter.module_accessor, vars::ken::status::flag::SPECIAL_N2_GROUND_BRANCH_H) {
+        let mot = VarModule::get_int64(fighter.module_accessor, vars::ken::status::int64::SPECIAL_N2_GROUND_BRANCH_MOTION);
+        if mot == hash40("special_n2_s") {
+            MotionModule::change_motion(
+                fighter.module_accessor,
+                Hash40::new_raw(mot),
+                0.0,
+                1.0,
+                false,
+                0.0,
+                false,
+                false
+            );
+            VarModule::off_flag(fighter.module_accessor, vars::ken::status::flag::SPECIAL_N2_GROUND_BRANCH_H);
+            return 0.into();
+        }
+    }
+
+    if VarModule::is_flag(fighter.module_accessor, vars::ken::status::flag::SPECIAL_N2_GROUND_BRANCH_LM) {
+        let mot = VarModule::get_int64(fighter.module_accessor, vars::ken::status::int64::SPECIAL_N2_GROUND_BRANCH_MOTION);
+        if mot == hash40("special_n2_hi")
+        || mot == hash40("special_n2_lw") {
+            MotionModule::change_motion(
+                fighter.module_accessor,
+                Hash40::new_raw(mot),
+                0.0,
+                1.0,
+                false,
+                0.0,
+                false,
+                false
+            );
+            VarModule::off_flag(fighter.module_accessor, vars::ken::status::flag::SPECIAL_N2_GROUND_BRANCH_LM);
+            return 0.into();
+        }
+    }
+
+    if MotionModule::is_end(fighter.module_accessor) {
+        fighter.change_status(FIGHTER_STATUS_KIND_WAIT.into(), false.into());
+        return 0.into();
+    }
+
+    0.into()
+}
+
+pub unsafe extern "C" fn ken_attack_command1_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    EffectModule::kill_kind(
+        fighter.module_accessor,
+        Hash40::new("ken_syoryuken_fire"),
+        false,
+        true
+    );
+    0.into()
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Pre, *FIGHTER_RYU_STATUS_KIND_ATTACK_COMMAND1, ken_attack_command1_pre);
+    agent.status(Init, *FIGHTER_RYU_STATUS_KIND_ATTACK_COMMAND1, ken_attack_command1_init);
+    agent.status(Main, *FIGHTER_RYU_STATUS_KIND_ATTACK_COMMAND1, ken_attack_command1_main);
+    agent.status(End, *FIGHTER_RYU_STATUS_KIND_ATTACK_COMMAND1, ken_attack_command1_end);
+}

--- a/fighters/ken/src/status/special_n2.rs
+++ b/fighters/ken/src/status/special_n2.rs
@@ -6,16 +6,6 @@ extern "C" {
 }
 
 unsafe extern "C" fn ken_special_n2_command_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
-    let attr = if VarModule::is_flag(fighter.module_accessor, vars::ken::instance::flag::QUICK_STEP_INHERIT) {
-        0
-    }
-    else {
-        *FIGHTER_STATUS_ATTR_START_TURN
-    };
-
-    if !VarModule::is_flag(fighter.module_accessor, vars::ken::instance::flag::QUICK_STEP_INHERIT) {
-        fighter.sub_status_pre_SpecialNCommon();
-    }
     StatusModule::init_settings(
         fighter.module_accessor,
         SituationKind(*SITUATION_KIND_NONE),
@@ -40,7 +30,7 @@ unsafe extern "C" fn ken_special_n2_command_pre(fighter: &mut L2CFighterCommon) 
             *FIGHTER_LOG_MASK_FLAG_ACTION_TRIGGER_ON |
             *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_N2_COMMAND
         ) as u64,
-        attr as u32,
+        0 as u32,
         *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_S as u32,
         0
     );
@@ -55,197 +45,67 @@ unsafe extern "C" fn ken_special_n2_command_init(fighter: &mut L2CFighterCommon)
     WorkModule::on_flag(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_COMMON_FLAG_COMMAND);
     WorkModule::set_int64(fighter.module_accessor, hash40("special_n2") as i64, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_N_INT_MOTION_KIND);
     WorkModule::set_int64(fighter.module_accessor, hash40("special_air_n2") as i64, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_N_INT_MOTION_KIND_AIR);
-    if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_GROUND
-    || VarModule::is_flag(fighter.module_accessor, vars::ken::status::flag::QUICK_STEP_INHERITED) {
-        fighter.set_situation(SITUATION_KIND_AIR.into());
-        GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
-        let speed_x = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
-        let mut speed_y = KineticModule::get_sum_speed_y(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
-        let air_speed_y_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("air_speed_y_mul"));
-        speed_y *= air_speed_y_mul;
-        if speed_y < 0.0 {
-            speed_y = 0.0;
-        }
-        sv_kinetic_energy!(
-            reset_energy,
-            fighter,
-            FIGHTER_KINETIC_ENERGY_ID_MOTION,
-            ENERGY_MOTION_RESET_TYPE_AIR_TRANS,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0
-        );
-        KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_MOTION);
-        sv_kinetic_energy!(
-            reset_energy,
-            fighter,
-            FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
-            ENERGY_GRAVITY_RESET_TYPE_GRAVITY,
-            0.0,
-            speed_y,
-            0.0,
-            0.0,
-            0.0
-        );
-        KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-        let air_speed_x_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("air_speed_x_mul"));
-        sv_kinetic_energy!(
-            reset_energy,
-            fighter,
-            FIGHTER_KINETIC_ENERGY_ID_CONTROL,
-            ENERGY_CONTROLLER_RESET_TYPE_FALL_ADJUST,
-            speed_x * air_speed_x_mul,
-            0.0,
-            0.0,
-            0.0,
-            0.0
-        );
-        let air_speed_x_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_x_stable"), 0);
-        let control_limit_mul_x = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("control_limit_mul_x"));
-        sv_kinetic_energy!(
-            set_stable_speed,
-            fighter,
-            FIGHTER_KINETIC_ENERGY_ID_CONTROL,
-            air_speed_x_stable * control_limit_mul_x,
-            100.0
-        );
-        KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
-        KineticUtility::clear_unable_energy(*FIGHTER_KINETIC_ENERGY_ID_STOP, fighter.module_accessor);
-        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_DISABLE_AIR_SPECIAL_S);
+    fighter.set_situation(SITUATION_KIND_AIR.into());
+    GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+    let speed_x = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+    let mut speed_y = KineticModule::get_sum_speed_y(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+    let air_speed_y_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("air_speed_y_mul"));
+    speed_y *= air_speed_y_mul;
+    if speed_y < 0.0 {
+        speed_y = 0.0;
     }
-    else {
-        GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND_CLIFF_STOP));
-        KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION);
-    }
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_MOTION,
+        ENERGY_MOTION_RESET_TYPE_AIR_TRANS,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    );
+    KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_MOTION);
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        ENERGY_GRAVITY_RESET_TYPE_GRAVITY,
+        0.0,
+        speed_y,
+        0.0,
+        0.0,
+        0.0
+    );
+    KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+    let air_speed_x_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("air_speed_x_mul"));
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+        ENERGY_CONTROLLER_RESET_TYPE_FALL_ADJUST,
+        speed_x * air_speed_x_mul,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    );
+    let air_speed_x_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_x_stable"), 0);
+    let control_limit_mul_x = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("control_limit_mul_x"));
+    sv_kinetic_energy!(
+        set_stable_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+        air_speed_x_stable * control_limit_mul_x,
+        100.0
+    );
+    KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+    KineticUtility::clear_unable_energy(*FIGHTER_KINETIC_ENERGY_ID_STOP, fighter.module_accessor);
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_DISABLE_AIR_SPECIAL_S);
     0.into()
 }
 
 unsafe extern "C" fn ken_special_n2_command_main(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
-        ken_special_n2_ground_main(fighter)
-    }
-    else {
-        ken_special_n2_air_main(fighter)
-    }
-}
-
-unsafe extern "C" fn ken_special_n2_ground_main(fighter: &mut L2CFighterCommon) -> L2CValue {
-    VarModule::set_int64(fighter.module_accessor, vars::ken::status::int64::SPECIAL_N2_GROUND_BRANCH_MOTION, hash40("invalid"));
-    MotionModule::change_motion(
-        fighter.module_accessor,
-        Hash40::new("special_n2_start"),
-        0.0,
-        1.0,
-        false,
-        0.0,
-        false,
-        false
-    );
-    if !StopModule::is_stop(fighter.module_accessor) {
-        ken_special_n2_ground_substatus(fighter, false.into());
-    }
-    fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(ken_special_n2_ground_substatus as *const () as _));
-    fighter.sub_shift_status_main(L2CValue::Ptr(ken_special_n2_ground_main_loop as *const () as _))
-}
-
-unsafe extern "C" fn ken_special_n2_ground_substatus(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
-    if param_1.get_bool() {
-        WorkModule::inc_int(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_COMMON_INT_BUTTON_ON_TIMER);
-    }
-    if VarModule::is_flag(fighter.module_accessor, vars::ken::status::flag::SPECIAL_N2_GROUND_BRANCH_CHECK) {
-        if ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) {
-            let stick_x = fighter.global_table[STICK_X].get_f32();
-            let lr = PostureModule::lr(fighter.module_accessor);
-            let stick_y = fighter.global_table[STICK_Y].get_f32();
-            let squat_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("squat_stick_y"));
-            let mot = if stick_y > squat_stick_y.abs() {
-                hash40("special_n2_hi")
-            }
-            else if stick_y < squat_stick_y {
-                hash40("special_n2_lw")
-            }
-            else if stick_x * lr > squat_stick_y.abs() {
-                hash40("special_n2_s")
-            }
-            else {
-                hash40("invalid")
-            };
-            if mot != hash40("invalid") {
-                VarModule::set_int64(fighter.module_accessor, vars::ken::status::int64::SPECIAL_N2_GROUND_BRANCH_MOTION, mot);
-                VarModule::off_flag(fighter.module_accessor, vars::ken::status::flag::SPECIAL_N2_GROUND_BRANCH_CHECK);
-            }
-        }
-    }
-    0.into()
-}
-
-unsafe extern "C" fn ken_special_n2_ground_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if CancelModule::is_enable_cancel(fighter.module_accessor) {
-        if fighter.sub_wait_ground_check_common(false.into()).get_bool() {
-            return 1.into();
-        }
-    }
-    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL)
-    && AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_SHIELD | *COLLISION_KIND_MASK_HIT) {
-        let sitation = fighter.global_table[SITUATION_KIND].get_i32();
-        if ryu_final_hit_cancel(fighter, sitation.into()).get_bool() {
-            return 1.into();
-        }
-    }
-
-    if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_GROUND {
-        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
-        return 0.into();
-    }
-
-    if VarModule::is_flag(fighter.module_accessor, vars::ken::status::flag::SPECIAL_N2_GROUND_BRANCH_H) {
-        let mot = VarModule::get_int64(fighter.module_accessor, vars::ken::status::int64::SPECIAL_N2_GROUND_BRANCH_MOTION);
-        if mot == hash40("special_n2_s") {
-            MotionModule::change_motion(
-                fighter.module_accessor,
-                Hash40::new_raw(mot),
-                0.0,
-                1.0,
-                false,
-                0.0,
-                false,
-                false
-            );
-            VarModule::off_flag(fighter.module_accessor, vars::ken::status::flag::SPECIAL_N2_GROUND_BRANCH_H);
-            return 0.into();
-        }
-    }
-
-    if VarModule::is_flag(fighter.module_accessor, vars::ken::status::flag::SPECIAL_N2_GROUND_BRANCH_LM) {
-        let mot = VarModule::get_int64(fighter.module_accessor, vars::ken::status::int64::SPECIAL_N2_GROUND_BRANCH_MOTION);
-        if mot == hash40("special_n2_hi")
-        || mot == hash40("special_n2_lw") {
-            MotionModule::change_motion(
-                fighter.module_accessor,
-                Hash40::new_raw(mot),
-                0.0,
-                1.0,
-                false,
-                0.0,
-                false,
-                false
-            );
-            VarModule::off_flag(fighter.module_accessor, vars::ken::status::flag::SPECIAL_N2_GROUND_BRANCH_LM);
-            return 0.into();
-        }
-    }
-
-    if MotionModule::is_end(fighter.module_accessor) {
-        fighter.change_status(FIGHTER_STATUS_KIND_WAIT.into(), false.into());
-        return 0.into();
-    }
-
-    0.into()
-}
-
-unsafe extern "C" fn ken_special_n2_air_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     MotionModule::change_motion(
         fighter.module_accessor,
         Hash40::new("special_air_n2"),
@@ -257,13 +117,13 @@ unsafe extern "C" fn ken_special_n2_air_main(fighter: &mut L2CFighterCommon) -> 
         false
     );
     if !StopModule::is_stop(fighter.module_accessor) {
-        ken_special_n2_air_substatus(fighter, false.into());
+        ken_special_n2_substatus(fighter, false.into());
     }
-    fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(ken_special_n2_air_substatus as *const () as _));
-    fighter.sub_shift_status_main(L2CValue::Ptr(ken_special_n2_air_main_loop as *const () as _))
+    fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(ken_special_n2_substatus as *const () as _));
+    fighter.sub_shift_status_main(L2CValue::Ptr(ken_special_n2_main_loop as *const () as _))
 }
 
-unsafe extern "C" fn ken_special_n2_air_substatus(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
+unsafe extern "C" fn ken_special_n2_substatus(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
     if param_1.get_bool() {
         WorkModule::inc_int(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_COMMON_INT_BUTTON_ON_TIMER);
     }
@@ -274,7 +134,7 @@ unsafe extern "C" fn ken_special_n2_air_substatus(fighter: &mut L2CFighterCommon
     0.into()
 }
 
-unsafe extern "C" fn ken_special_n2_air_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+unsafe extern "C" fn ken_special_n2_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
     if CancelModule::is_enable_cancel(fighter.module_accessor) {
         if fighter.sub_air_check_fall_common().get_bool() {
             return 1.into();

--- a/fighters/kirby/src/agent_init.rs
+++ b/fighters/kirby/src/agent_init.rs
@@ -44,8 +44,52 @@ unsafe extern "C" fn kirby_specialn_pre(fighter: &mut L2CFighterCommon) -> L2CVa
     0.into()
 }
 
+unsafe extern "C" fn kirby_check_special_command(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_KIRBY_INSTANCE_WORK_ID_FLAG_COPY) {
+        return 0.into();
+    }
+    let copy_chara = WorkModule::get_int(fighter.module_accessor, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA);
+    let cat4 = fighter.global_table[CMD_CAT4].get_i32();
+
+    if copy_chara == *FIGHTER_KIND_RYU {
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N2_COMMAND != 0
+        && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N2_COMMAND)
+        && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[CHECK_SPECIAL_N_UNIQ].clone()).get_bool() {
+            fighter.change_status(FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N2_COMMAND.into(), true.into());
+            return true.into();
+        }
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
+        && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND)
+        && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[CHECK_SPECIAL_N_UNIQ].clone()).get_bool() {
+            fighter.change_status(FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N_COMMAND.into(), true.into());
+            return true.into();
+        }
+    }
+
+    if copy_chara == *FIGHTER_KIND_KEN {
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
+        && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND)
+        && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[CHECK_SPECIAL_N_UNIQ].clone()).get_bool() {
+            fighter.change_status(FIGHTER_KIRBY_STATUS_KIND_KEN_SPECIAL_N_COMMAND.into(), true.into());
+            return true.into();
+        }
+    }
+
+    if copy_chara == *FIGHTER_KIND_DOLLY {
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
+        && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND)
+        && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[CHECK_SPECIAL_N_UNIQ].clone()).get_bool() {
+            fighter.change_status(vars::kirby::status::DOLLY_SPECIAL_N_COMMAND.into(), true.into());
+            return true.into();
+        }
+    }
+
+    0.into()
+}
+
 unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {
     fighter.global_table[CHECK_SPECIAL_N_UNIQ].assign(&L2CValue::Ptr(kirby_specialn_pre as *const () as _));
+    fighter.global_table[CHECK_SPECIAL_COMMAND].assign(&L2CValue::Ptr(kirby_check_special_command as *const () as _));
     FGCModule::clone_command_input(fighter.module_accessor, Cat4::SPECIAL_S_COMMAND, Cat4::SPECIAL_N2_COMMAND);
 }
 

--- a/fighters/kirby/src/agent_init.rs
+++ b/fighters/kirby/src/agent_init.rs
@@ -90,7 +90,7 @@ unsafe extern "C" fn kirby_check_special_command(fighter: &mut L2CFighterCommon)
 unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {
     fighter.global_table[CHECK_SPECIAL_N_UNIQ].assign(&L2CValue::Ptr(kirby_specialn_pre as *const () as _));
     fighter.global_table[CHECK_SPECIAL_COMMAND].assign(&L2CValue::Ptr(kirby_check_special_command as *const () as _));
-    FGCModule::clone_command_input(fighter.module_accessor, Cat4::SPECIAL_S_COMMAND, Cat4::SPECIAL_N2_COMMAND);
+    // FGCModule::clone_command_input(fighter.module_accessor, Cat4::SPECIAL_S_COMMAND, Cat4::SPECIAL_N2_COMMAND);
 }
 
 pub fn install(agent: &mut Agent) {

--- a/fighters/kirby/src/agent_init.rs
+++ b/fighters/kirby/src/agent_init.rs
@@ -46,6 +46,7 @@ unsafe extern "C" fn kirby_specialn_pre(fighter: &mut L2CFighterCommon) -> L2CVa
 
 unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {
     fighter.global_table[CHECK_SPECIAL_N_UNIQ].assign(&L2CValue::Ptr(kirby_specialn_pre as *const () as _));
+    FGCModule::clone_command_input(fighter.module_accessor, Cat4::SPECIAL_S_COMMAND, Cat4::SPECIAL_N2_COMMAND);
 }
 
 pub fn install(agent: &mut Agent) {

--- a/fighters/kirby/src/lib.rs
+++ b/fighters/kirby/src/lib.rs
@@ -20,6 +20,15 @@ mod status;
 mod agent_init;
 pub mod vl;
 
+// static RYU_COPY_MOTIONS : [u64; 6] = [
+//     0xd5899ddb0, 0x915c5de42,
+//     0x11787641d2, 0xd483c0ed2,
+//     0xed1ec945c, 0xa82125b6f,
+//     0x1272707bb4, 0xe724031fb,
+//     // Pad with the beginning of the next table
+//     0xdefce9270, 0x915c5de42
+// ];
+
 pub fn install() {
     let agent = &mut Agent::new("kirby");
     acmd::install(agent);
@@ -27,4 +36,24 @@ pub fn install() {
     status::install(agent);
     agent_init::install(agent);
     agent.install();
+
+    // MiscModule::patch_vtable_function(0x52c1950, RYU_COPY_MOTIONS.as_ptr() as u64);
+    // let _ = skyline::patching::Patch::in_text(0x413698).data(0x321A03E1u32);
+    // let _ = skyline::patching::Patch::in_text(0x4136d8).data(0x321A03E1u32);
+
+    // let _ = skyline::patching::Patch::in_text(0x4136f8).data(0x91010008u32);
+    // unsafe {
+    //     let text = skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64 + 0x52c1950;
+    //     let ryu_copy_table = *(text as *mut *mut u64);
+    //     println!("table: {:#?}", ryu_copy_table);
+    //     for index in 0..16 {
+    //         println!("{:#x}", *ryu_copy_table.add(index));
+    //     }
+    //     // let mut ryu_copy_motion = RYU_COPY_MOTIONS.as_ptr();
+    //     // println!("motions: {:#?}", ryu_copy_motion);
+    //     // while *ryu_copy_motion != 0 {
+    //     //     println!("{:#x}", *ryu_copy_motion);
+    //     //     ryu_copy_motion = ryu_copy_motion.add(1);
+    //     // }
+    // }
 }

--- a/fighters/kirby/src/status.rs
+++ b/fighters/kirby/src/status.rs
@@ -6,6 +6,7 @@ mod koopa;
 mod ganon;
 mod lucario;
 mod ike;
+// mod ryu;
 mod belmont;
 mod jack;
 mod dolly;
@@ -17,6 +18,7 @@ pub fn install(agent: &mut Agent) {
     ganon::install(agent);
     lucario::install(agent);
     ike::install(agent);
+    // ryu::install(agent);
     belmont::install(agent);
     jack::install(agent);
     dolly::install(agent);

--- a/fighters/kirby/src/status.rs
+++ b/fighters/kirby/src/status.rs
@@ -8,6 +8,7 @@ mod lucario;
 mod ike;
 mod belmont;
 mod jack;
+mod dolly;
 
 pub fn install(agent: &mut Agent) {
     kirby::install(agent);
@@ -18,4 +19,5 @@ pub fn install(agent: &mut Agent) {
     ike::install(agent);
     belmont::install(agent);
     jack::install(agent);
+    dolly::install(agent);
 }

--- a/fighters/kirby/src/status/dolly.rs
+++ b/fighters/kirby/src/status/dolly.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+unsafe extern "C" fn kirby_dolly_special_n_command_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_NONE),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_KEEP as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        (
+            *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_N |
+            *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK |
+            *FIGHTER_LOG_MASK_FLAG_ACTION_TRIGGER_ON |
+            *FIGHTER_LOG_MASK_FLAG_SHOOT
+        ) as u64,
+        *FIGHTER_STATUS_ATTR_START_TURN as u32,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_N as u32,
+        0
+    );
+    0.into()
+}
+
+unsafe extern "C" fn kirby_dolly_special_n_command_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    smashline::original_status(Main, fighter, *FIGHTER_KIRBY_STATUS_KIND_DOLLY_SPECIAL_N)(fighter)
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Pre, vars::kirby::status::DOLLY_SPECIAL_N_COMMAND, kirby_dolly_special_n_command_pre);
+    agent.status(Main, vars::kirby::status::DOLLY_SPECIAL_N_COMMAND, kirby_dolly_special_n_command_main);
+}

--- a/fighters/kirby/src/status/ryu.rs
+++ b/fighters/kirby/src/status/ryu.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+mod special_n2;
+
+pub fn install(agent: &mut Agent) {
+    special_n2::install(agent);
+}

--- a/fighters/kirby/src/status/ryu/special_n2.rs
+++ b/fighters/kirby/src/status/ryu/special_n2.rs
@@ -1,0 +1,261 @@
+use super::*;
+
+unsafe extern "C" fn kirby_ryu_special_n2_command_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.sub_status_pre_SpecialNCommon();
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_NONE),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_KEEP as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        (
+            *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK |
+            *FIGHTER_LOG_MASK_FLAG_ACTION_TRIGGER_ON |
+            *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_N2_COMMAND
+        ) as u64,
+        0,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_N as u32,
+        0
+    );
+    0.into()
+}
+
+unsafe extern "C" fn kirby_ryu_special_n2_command_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_COMMON_FLAG_COMMAND);
+    WorkModule::set_int64(fighter.module_accessor, hash40("special_n2") as i64, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_N_INT_MOTION_KIND);
+    WorkModule::set_int64(fighter.module_accessor, hash40("special_air_n2") as i64, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_N_INT_MOTION_KIND_AIR);
+    let speed_x = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+    let mut speed_y = KineticModule::get_sum_speed_y(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        let speed_x_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("speed_x_mul"));
+        KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_MOTION);
+        sv_kinetic_energy!(
+            reset_energy,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_MOTION,
+            ENERGY_MOTION_RESET_TYPE_GROUND_TRANS,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0
+        );
+        sv_kinetic_energy!(
+            set_speed_mul,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_MOTION,
+            1.5
+        );
+        KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_STOP);
+        sv_kinetic_energy!(
+            reset_energy,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_STOP,
+            ENERGY_STOP_RESET_TYPE_GROUND,
+            speed_x * speed_x_mul,
+            0.0,
+            0.0,
+            0.0,
+            0.0
+        );
+        KineticUtility::clear_unable_energy(*FIGHTER_KINETIC_ENERGY_ID_CONTROL, fighter.module_accessor);
+    }
+    else {
+        if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_SPECIAL_AIR_N) {
+            let air_speed_y_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("air_speed_y_mul"));
+            speed_y *= air_speed_y_mul;
+        }
+        if speed_y < 0.0 {
+            speed_y = 0.0;
+        }
+        sv_kinetic_energy!(
+            reset_energy,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_MOTION,
+            ENERGY_MOTION_RESET_TYPE_AIR_TRANS,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0
+        );
+        KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_MOTION);
+        sv_kinetic_energy!(
+            reset_energy,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+            ENERGY_GRAVITY_RESET_TYPE_GRAVITY,
+            0.0,
+            speed_y,
+            0.0,
+            0.0,
+            0.0
+        );
+        KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+        let air_speed_x_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("air_speed_x_mul"));
+        sv_kinetic_energy!(
+            reset_energy,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+            ENERGY_CONTROLLER_RESET_TYPE_FALL_ADJUST,
+            speed_x * air_speed_x_mul,
+            0.0,
+            0.0,
+            0.0,
+            0.0
+        );
+        let air_speed_x_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_x_stable"), 0);
+        let control_limit_mul_x = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("control_limit_mul_x"));
+        sv_kinetic_energy!(
+            set_stable_speed,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+            air_speed_x_stable * control_limit_mul_x,
+            100.0
+        );
+        KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+        KineticUtility::clear_unable_energy(*FIGHTER_KINETIC_ENERGY_ID_STOP, fighter.module_accessor);
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_SPECIAL_AIR_N);
+    }
+    0.into()
+}
+
+unsafe extern "C" fn kirby_ryu_special_n2_command_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if !StopModule::is_stop(fighter.module_accessor) {
+        kirby_ryu_special_n2_substatus(fighter, false.into());
+    }
+    fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(kirby_ryu_special_n2_substatus as *const () as _));
+    fighter.sub_shift_status_main(L2CValue::Ptr(kirby_ryu_special_n2_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn kirby_ryu_special_n2_substatus(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
+    if param_1.get_bool() {
+        WorkModule::inc_int(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_COMMON_INT_BUTTON_ON_TIMER);
+    }
+    0.into()
+}
+
+unsafe extern "C" fn kirby_ryu_special_n2_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if CancelModule::is_enable_cancel(fighter.module_accessor) {
+        if fighter.sub_wait_ground_check_common(false.into()).get_bool()
+        || fighter.sub_air_check_fall_common().get_bool() {
+            return 1.into();
+        }
+    }
+    // if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL)
+    // && AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_SHIELD | *COLLISION_KIND_MASK_HIT) {
+    //     let sitation = fighter.global_table[SITUATION_KIND].get_i32();
+    //     if ryu_final_hit_cancel(fighter, sitation.into()).get_bool() {
+    //         return 1.into();
+    //     }
+    // }
+    if StatusModule::is_changing(fighter.module_accessor)
+    || StatusModule::is_situation_changed(fighter.module_accessor) {
+        if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_GROUND {
+            GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+            let mot_air = WorkModule::get_int64(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_N_INT_MOTION_KIND_AIR);
+            if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_COMMON_FLAG_MOTION_FIRST) {
+                FighterMotionModuleImpl::change_motion_kirby_copy(
+                    fighter.module_accessor,
+                    Hash40::new_raw(mot_air),
+                    0.0,
+                    1.0,
+                    false,
+                    0.0,
+                    false,
+                    false
+                );
+                WorkModule::on_flag(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_COMMON_FLAG_MOTION_FIRST);
+            }
+            else {
+                FighterMotionModuleImpl::change_motion_inherit_frame_kirby_copy(
+                    fighter.module_accessor,
+                    Hash40::new_raw(mot_air),
+                    -1.0,
+                    1.0,
+                    0.0,
+                    false,
+                    false
+                );
+            }
+            if !StatusModule::is_changing(fighter.module_accessor) {
+                KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
+                let air_speed_x_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_x_stable"), 0);
+                let control_limit_mul_x = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("control_limit_mul_x"));
+                sv_kinetic_energy!(
+                    set_limit_speed,
+                    fighter,
+                    FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+                    air_speed_x_stable * control_limit_mul_x,
+                    0.0
+                );
+            }
+        }
+        else {
+            GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND_CLIFF_STOP));
+            let mot_ground = WorkModule::get_int64(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_N_INT_MOTION_KIND);
+            if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_COMMON_FLAG_MOTION_FIRST) {
+                FighterMotionModuleImpl::change_motion_kirby_copy(
+                    fighter.module_accessor,
+                    Hash40::new_raw(mot_ground),
+                    0.0,
+                    1.0,
+                    false,
+                    0.0,
+                    false,
+                    false
+                );
+                WorkModule::on_flag(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_COMMON_FLAG_MOTION_FIRST);
+            }
+            else {
+                FighterMotionModuleImpl::change_motion_inherit_frame_kirby_copy(
+                    fighter.module_accessor,
+                    Hash40::new_raw(mot_ground),
+                    -1.0,
+                    1.0,
+                    0.0,
+                    false,
+                    false
+                );
+            }
+            if !StatusModule::is_changing(fighter.module_accessor) {
+                KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION);
+                sv_kinetic_energy!(
+                    set_speed_mul,
+                    fighter,
+                    FIGHTER_KINETIC_ENERGY_ID_MOTION,
+                    1.5
+                );
+            }
+        }
+    }
+    if MotionModule::is_end(fighter.module_accessor) {
+        let status = if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+            FIGHTER_STATUS_KIND_WAIT
+        }
+        else {
+            FIGHTER_STATUS_KIND_FALL
+        };
+        fighter.change_status(status.into(), false.into());
+    }
+    0.into()
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Pre, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N2_COMMAND, kirby_ryu_special_n2_command_pre);
+    agent.status(Init, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N2_COMMAND, kirby_ryu_special_n2_command_init);
+    agent.status(Main, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N2_COMMAND, kirby_ryu_special_n2_command_main);
+}

--- a/fighters/ryu/src/agent_init.rs
+++ b/fighters/ryu/src/agent_init.rs
@@ -7,11 +7,13 @@ extern "C" {
 
 pub unsafe extern "C" fn ryu_check_special_command(fighter: &mut L2CFighterCommon) -> L2CValue {
     if VarModule::is_flag(fighter.module_accessor, vars::ryu::instance::flag::DENJIN_CHARGE)
+    && !fighter.global_table[IS_STOP].get_bool()
     && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW) {
-        let pad_flag = fighter.global_table[PAD_FLAG].get_i32();
-        if pad_flag & *FIGHTER_PAD_FLAG_GUARD_TRIGGER != 0
-        && pad_flag & *FIGHTER_PAD_FLAG_SPECIAL_TRIGGER != 0 {
+        let cat1 = fighter.global_table[CMD_CAT1].get_i32();
+        let cat2 = fighter.global_table[CMD_CAT2].get_i32();
+        if cat2 & *FIGHTER_PAD_CMD_CAT2_FLAG_COMMON_GUARD != 0
+        && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_N != 0 {
             fighter.change_status(FIGHTER_RYU_STATUS_KIND_SPECIAL_LW_STEP_B.into(), true.into());
             return true.into();
         }

--- a/fighters/ryu/src/status/guard.rs
+++ b/fighters/ryu/src/status/guard.rs
@@ -7,7 +7,7 @@ unsafe extern "C" fn ryu_guard_main(fighter: &mut L2CFighterCommon) -> L2CValue 
 
 unsafe extern "C" fn ryu_guard_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
     if VarModule::is_flag(fighter.module_accessor, vars::ryu::instance::flag::DENJIN_CHARGE)
-    && ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) {
+    && ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) {
         fighter.change_status(FIGHTER_RYU_STATUS_KIND_SPECIAL_LW_STEP_B.into(), true.into());
         return 1.into();
     }

--- a/fighters/ryu/src/status/guard_on.rs
+++ b/fighters/ryu/src/status/guard_on.rs
@@ -7,7 +7,7 @@ unsafe extern "C" fn ryu_guard_on_main(fighter: &mut L2CFighterCommon) -> L2CVal
 
 unsafe extern "C" fn ryu_guard_on_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
     if VarModule::is_flag(fighter.module_accessor, vars::ryu::instance::flag::DENJIN_CHARGE)
-    && ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) {
+    && ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) {
         fighter.change_status(FIGHTER_RYU_STATUS_KIND_SPECIAL_LW_STEP_B.into(), true.into());
         return 1.into();
     }

--- a/fighters/ryu/src/status/special_n2.rs
+++ b/fighters/ryu/src/status/special_n2.rs
@@ -27,7 +27,7 @@ unsafe extern "C" fn ryu_special_n2_command_pre(fighter: &mut L2CFighterCommon) 
             *FIGHTER_LOG_MASK_FLAG_ACTION_TRIGGER_ON |
             *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_N2_COMMAND
         ) as u64,
-        *FIGHTER_STATUS_ATTR_START_TURN as u32,
+        0,
         *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_N as u32,
         0
     );

--- a/src/vtable_hook/dolly.rs
+++ b/src/vtable_hook/dolly.rs
@@ -5,6 +5,107 @@ extern "C" {
     fn add_go(module_accessor: *mut BattleObjectModuleAccessor, amount: f32);
 }
 
+#[repr(C)]
+pub struct NoSpecial {
+    no: i32,
+    special: i32
+}
+
+pub unsafe extern "C" fn dolly_handle_special_strength(module_accessor: *mut BattleObjectModuleAccessor, no: i32, special: i32) -> NoSpecial {
+    if !WorkModule::is_flag(module_accessor, *FIGHTER_DOLLY_STATUS_SPECIAL_COMMON_WORK_FLAG_DECIDE_STRENGTH) {
+        let special_pad_release_w = WorkModule::get_param_int(module_accessor, hash40("param_private"), hash40("special_pad_release_w"));
+        let strength = WorkModule::get_int(module_accessor, *FIGHTER_DOLLY_STATUS_SPECIAL_COMMON_WORK_INT_STRENGTH);
+        let button_on_timer = WorkModule::get_int(module_accessor, *FIGHTER_DOLLY_STATUS_SPECIAL_COMMON_WORK_INT_BUTTON_ON_TIMER);
+        if strength == 0 && ControlModule::get_button(module_accessor) & 3 == 0
+        && button_on_timer <= special_pad_release_w {
+            WorkModule::set_int(module_accessor, *FIGHTER_DOLLY_STRENGTH_W, *FIGHTER_DOLLY_STATUS_SPECIAL_COMMON_WORK_INT_STRENGTH);
+            return NoSpecial{no, special};
+        }
+    }
+    NoSpecial{no: -1, special: -1}
+}
+
+#[skyline::hook(offset = 0x971490)]
+pub unsafe extern "C" fn dolly_per_frame(_vtable: u64, fighter: &mut Fighter) {
+    let module_accessor = fighter.battle_object.module_accessor;
+    let status = StatusModule::status_kind(module_accessor);
+    let thing = match status {
+        0x29 | 0x203 => {
+            if !WorkModule::is_flag(module_accessor, *FIGHTER_DOLLY_STATUS_SPECIAL_COMMON_WORK_FLAG_DECIDE_STRENGTH) {
+                let special_pad_release_w = WorkModule::get_param_int(module_accessor, hash40("param_private"), hash40("special_pad_release_w"));
+                let strength = VarModule::get_int(module_accessor, dolly::status::int::ATTACK_DASH_STRENGTH);
+                let button_on_timer = WorkModule::get_int(module_accessor, *FIGHTER_DOLLY_STATUS_SPECIAL_COMMON_WORK_INT_BUTTON_ON_TIMER);
+                if strength == 0 && ControlModule::get_button(module_accessor) & 3 == 0
+                && button_on_timer <= special_pad_release_w {
+                    VarModule::set_int(module_accessor, dolly::status::int::ATTACK_DASH_STRENGTH, *FIGHTER_DOLLY_STRENGTH_W);
+                }
+            }
+            NoSpecial{no: -1, special: -1}
+        }
+        0x1dc /*| 0x204*/ => dolly_handle_special_strength(module_accessor, 0, 0),
+        0x1dd | 0x1eb => dolly_handle_special_strength(module_accessor, 0, 1),
+        0x1de | 0x1f5 => dolly_handle_special_strength(module_accessor, 0, 2),
+        0x1df | 0x1f6 => dolly_handle_special_strength(module_accessor, 0, 3),
+        0x1ee | 0x1ef => dolly_handle_special_strength(module_accessor, 2, 1),
+        _ => NoSpecial{no: -1, special: -1}
+    };
+    if thing.no != -1 {
+        WorkModule::set_customize_no(module_accessor, thing.no, thing.special);
+    }
+
+    let something = if [
+        0x1f4, 0x1fa, 0x1fb
+    ].contains(&status) {
+        true
+    }
+    else {
+        StopModule::is_damage(module_accessor)
+    };
+    dolly_transition_handler(module_accessor, something as u32, 0);
+
+    let battle_object_slow = singletons::BattleObjectSlow() as *mut u8;
+    if *battle_object_slow.add(0x8) != 0 && *(battle_object_slow as *const u32) != 2 {
+        return;
+    }
+
+    if !WorkModule::is_flag(module_accessor, 0x200000E6)
+    || !WorkModule::is_flag(module_accessor, *FIGHTER_DOLLY_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL)
+    || ControlModule::get_command_flag_cat(module_accessor, 0) >> 0xc & 1 == 0
+    || dolly_what_is_this(*(module_accessor as *const *const u64).add(0x50 / 8)) & 1 == 0 {
+        if StatusModule::situation_kind(module_accessor) == *SITUATION_KIND_AIR {
+            let something = if PostureModule::lr(module_accessor) == -1.0 {
+                0x10
+            }
+            else {
+                0x8
+            };
+            if *(*(module_accessor as *const *const u64).add(0x48 / 8) as *const u32).add(0xaa8 / 4) & something != 0 {
+                if StopModule::is_stop(module_accessor) && StopModule::is_hit(module_accessor) {
+                    return;
+                }
+                WorkModule::inc_int(module_accessor, *FIGHTER_DOLLY_INSTANCE_WORK_ID_INT_AIR_STICK_BACK_FRAME);
+                return;
+            }
+        }
+        WorkModule::set_int(module_accessor, 0, *FIGHTER_DOLLY_INSTANCE_WORK_ID_INT_AIR_STICK_BACK_FRAME);
+    }
+    else {
+        if StopModule::is_stop(module_accessor) && StopModule::is_hit(module_accessor) {
+            StopModule::cancel_hit_stop(module_accessor);
+        }
+        if 1 < SlowModule::frame(module_accessor, 1) {
+            SlowModule::clear_immediate(module_accessor, 1, false);
+        }
+        StatusModule::change_status_request(module_accessor, *FIGHTER_STATUS_KIND_FINAL, true);
+    }
+}
+
+#[skyline::from_offset(0x69ae40)]
+unsafe extern "C" fn dolly_transition_handler(module_accessor: *mut BattleObjectModuleAccessor, param_1: u32, param_2: u32);
+
+#[skyline::from_offset(0x695c80)]
+unsafe extern "C" fn dolly_what_is_this(workmodule: *const u64) -> u32;
+
 #[skyline::hook(offset = 0x971250)]
 pub unsafe extern "C" fn dolly_check_super_special(work: u64, _damage: u64) -> u64 {
     let module_accessor = &mut *(*((work as *mut u64).offset(1)) as *mut BattleObjectModuleAccessor);
@@ -30,10 +131,10 @@ pub unsafe extern "C" fn dolly_handle_special_command_turnaround(_vtable: u64, f
     let mut some_bool = false;
     let mut some_int = -1;
     let mut some_bool2 = false;
-    if 0x1E >= status - 0x1DC {
+    // if 0x1E >= status - 0x1DC {
         match status {
             0x1DC..=0x1E0 => some_bool2 = true,
-            0x1EB => some_int = 0,
+            0x1EB => some_int = 6,
             0x1EF => some_int = 2,
             0x1F5 => some_int = 7,
             0x1F6 => some_int = 3,
@@ -50,9 +151,10 @@ pub unsafe extern "C" fn dolly_handle_special_command_turnaround(_vtable: u64, f
                     some_int += 1;
                 }
             },
+            // 0x204 => some_int = 0,
             _ => {}
         }
-    }
+    // }
     let lr = PostureModule::lr(module_accessor);
     let mut skip_reset = false;
     if some_int < 0 {
@@ -101,6 +203,7 @@ unsafe extern "C" fn dolly_on_attack_inner(vtable: u64, fighter: &mut Fighter, l
 
 pub fn install() {
     skyline::install_hooks!(
+        dolly_per_frame,
         dolly_check_super_special,
         dolly_handle_special_command_turnaround
     );

--- a/src/vtable_hook/dolly.rs
+++ b/src/vtable_hook/dolly.rs
@@ -42,7 +42,7 @@ pub unsafe extern "C" fn dolly_per_frame(_vtable: u64, fighter: &mut Fighter) {
             }
             NoSpecial{no: -1, special: -1}
         }
-        0x1dc /*| 0x204*/ => dolly_handle_special_strength(module_accessor, 0, 0),
+        0x1dc | 0x204 => dolly_handle_special_strength(module_accessor, 0, 0),
         0x1dd | 0x1eb => dolly_handle_special_strength(module_accessor, 0, 1),
         0x1de | 0x1f5 => dolly_handle_special_strength(module_accessor, 0, 2),
         0x1df | 0x1f6 => dolly_handle_special_strength(module_accessor, 0, 3),

--- a/src/vtable_hook/shotos.rs
+++ b/src/vtable_hook/shotos.rs
@@ -5,15 +5,19 @@ unsafe extern "C" fn ryu_ken_init(_vtable: u64, fighter: &mut Fighter) {
     let module_accessor = fighter.battle_object.module_accessor;
     let control_energy = KineticModule::get_energy(module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
     *(control_energy as *mut u8).add(0xa4) = 1;
-    FGCModule::set_command_input_button(module_accessor, 0, 2);
-    FGCModule::set_command_input_button(module_accessor, 1, 2);
-    FGCModule::set_command_input_button(module_accessor, 2, 2);
-    FGCModule::set_command_input_button(module_accessor, 3, 2);
-    FGCModule::set_command_input_button(module_accessor, 7, 2);
-    FGCModule::set_command_input_button(module_accessor, 8, 2);
-    FGCModule::set_command_input_button(module_accessor, 9, 2);
-    FGCModule::set_command_input_button(module_accessor, 10, 2);
-    FGCModule::set_command_input_button(module_accessor, 11, 2);
+    FGCModule::set_command_input_button(module_accessor, Cat4::SPECIAL_N_COMMAND, 1);
+    FGCModule::set_command_input_button(module_accessor, Cat4::SPECIAL_S_COMMAND, 2);
+    FGCModule::set_command_input_button(module_accessor, Cat4::SPECIAL_HI_COMMAND, 1);
+    if fighter.battle_object.kind == 0x3c {
+        FGCModule::clone_command_input(module_accessor, Cat4::SPECIAL_S_COMMAND, Cat4::SPECIAL_N2_COMMAND);
+        FGCModule::set_command_input_button(module_accessor, Cat4::SPECIAL_N2_COMMAND, 1);
+    }
+    else {
+        FGCModule::clone_command_input(module_accessor, Cat4::SPECIAL_HI_COMMAND, Cat4::SPECIAL_N2_COMMAND);
+        FGCModule::set_command_input_button(module_accessor, Cat4::SPECIAL_N2_COMMAND, 2);
+        FGCModule::clone_command_input(module_accessor, Cat4::SPECIAL_N_COMMAND, Cat4::ATTACK_COMMAND1);
+        FGCModule::set_command_input_button(module_accessor, Cat4::ATTACK_COMMAND1, 2);
+    }
 }
 
 #[skyline::from_offset(0x646fe0)]


### PR DESCRIPTION
# Changelog

## General
- Cleaned up the custom command input shenanigans

## Kirby
Groundwork done to give him Hashogeki in the future. Due to limitations, we can't give it to him quite yet, so for now he gets to have Denjin Hadoken on command.

## Ryu
Command Inputs have been updated to be similar to SF6:
```
Hadoken: 236B > 236A
Hashogeki: 41236B > 214A
Tatsumaki Senpukyaku: 214B (unchanged)
Shoryuken: 623B > 623A
```

### Hashogeki (214A)
Removed the ability to b reverse it due to the input being changed.

## Ken
Command Inputs have been updated to be similar to SF6:
```
Hadoken: 236B > 236A
Tatsumaki Senpukyaku: 214B (unchanged)
Shoryuken: 623B > 623A
Jinrai Kicks: 41236B (Ground) > 236B (Ground Only)
Dragonlash Kick: 41236(Air/During Quick Dash) > 623B (can now be used normally on the ground)
```

## Terry
Command Inputs have been updated to be similar to KOF/Fatal Fury:
```
Power Wave: N/A > 236A
Burn Knuckle: 236AB > 214A
Crack Shoot: 214AB > 214B
Power Charge: 41236A (unchaged)
Power Dunk: 623AB > 623B
Rising Tackle: [2]8AB > [2]8A
Power Geyser: 21416AB > 21416A
Buster Wolf: 236236AB > 236236B
```
### Power Charge (Dash Attack/41236B)
Strength now works like all of Terry's other specials, instead of being dependent on if you used Dash Attack or the command input to perform it.
- Notably this lets you cancel into light Power Charge, then cancel that into Power Dunk.
- Also lets you perform Heavy Power Charge without the command input.