### PR TITLE
Parry Adjustments

### DIFF
--- a/fighters/common/src/status/guard/guard_on.rs
+++ b/fighters/common/src/status/guard/guard_on.rs
@@ -5,23 +5,13 @@ unsafe extern "C" fn sub_ftstatusuniqprocessguardon_initstatus_common(fighter: &
     // Original
     ShieldModule::set_status(fighter.module_accessor, *FIGHTER_SHIELD_KIND_GUARD, ShieldStatus(*SHIELD_STATUS_NORMAL), 0);
     // Additions
-    let was_parry = fighter.global_table[PREV_STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_GUARD_DAMAGE;
     let guard_trigger = fighter.global_table[PAD_FLAG].get_i32() & *FIGHTER_PAD_FLAG_GUARD_TRIGGER != 0;
     // println!("Held Shield for {} frames, can parry? {}", guard_trigger, guard_trigger <= 5 || was_parry);
     if FighterUtil::is_valid_just_shield(fighter.module_accessor)
-    && (
-        guard_trigger
-        || was_parry
-    ) {
+    && guard_trigger {
         let shield_just_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("shield_just_frame")) as f32;
         let just_shield_check_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("just_shield_check_frame"), 0);
-        let just_frame_add = if was_parry {
-            3.0
-        }
-        else {
-            0.0
-        };
-        let just_frame = (shield_just_frame * just_shield_check_frame + 0.5 + just_frame_add) as i32;
+        let just_frame = (shield_just_frame * just_shield_check_frame + 0.5) as i32;
         WorkModule::set_int(fighter.module_accessor, just_frame, *FIGHTER_STATUS_GUARD_ON_WORK_INT_JUST_FRAME);
         ShieldModule::set_shield_type(fighter.module_accessor, ShieldType(*SHIELD_TYPE_JUST_SHIELD), *FIGHTER_SHIELD_KIND_GUARD, 0);
         if FighterUtil::is_valid_just_shield_reflector(fighter.module_accessor) {

--- a/src/system/engine.rs
+++ b/src/system/engine.rs
@@ -15,12 +15,23 @@ unsafe fn autoturn_handler(_module_accessor: *mut BattleObjectModuleAccessor, _s
     0.0
 }
 
+// Forces parry hitlag to be a constant value
+#[skyline::hook(offset = 0x641d84, inline)]
+unsafe fn set_parry_hitlag(ctx: &mut skyline::hooks::InlineCtx) {
+    let parry_hitlag = *ctx.registers[28].w.as_ref();
+    *ctx.registers[26].x.as_mut() = parry_hitlag as u64;
+}
+
 pub fn install() {
-    skyline::install_hooks!(
-        change_elec_hitlag_for_attacker,
-        autoturn_handler
-    );
+    // Stubs parry hitlag calculation
+    skyline::patching::Patch::in_text(0x641d84).nop();
 
     // Removes Phantom Hits
     skyline::patching::Patch::in_text(0x3e6d08).data(0x14000012u32);
+
+    skyline::install_hooks!(
+        change_elec_hitlag_for_attacker,
+        autoturn_handler,
+        set_parry_hitlag
+    );
 }


### PR DESCRIPTION
# Changelog

- Parrying requires fresh inputs every time (it will not automatically parry multihits by holding Shield after the first parry).
- Hitlag is now static, regardless of the strength of the move parried.
  - If the attack parried was a direct attack: 18 frames
  - If the attack parried was an indirect attack: 7 frames