### PR TITLE
Knockback Visual Adjustments

### DIFF
--- a/fighters/common/src/status/damage/damage_fly.rs
+++ b/fighters/common/src/status/damage/damage_fly.rs
@@ -134,13 +134,22 @@ unsafe extern "C" fn sub_update_damage_fly_effect(
             EffectModule::preset_lifetime_rate_partial(fighter.module_accessor, fly_effect_smoke_life_min_rate);
             // </WuBor>
         }
+
+        // <WuBor>
+        let size = if effect_hash.get_u64() == hash40("sys_flyroll_aura") {
+            0.65
+        }
+        else {
+            0.8
+        };
+        // </WuBor>
         effect_id = EffectModule::req_follow(
             fighter.module_accessor,
             Hash40::new_raw(effect_hash.get_u64()),
             Hash40::new_raw(damage_fly_smoke_node),
             &Vector3f{x: damage_fly_smoke_offset_x, y: damage_fly_smoke_offset_y, z: 0.0},
             &Vector3f{x: 0.0, y: 0.0, z: 0.0},
-            1.0,
+            size,
             true,
             0,
             some_val.get_i32(),
@@ -168,6 +177,13 @@ unsafe extern "C" fn sub_update_damage_fly_effect(
             let team_color = FighterUtil::get_effect_team_color(EColorKind(attacker_color.get_i32()), Hash40::new_raw(color_hash));
             EffectModule::set_rgb_partial_last(fighter.module_accessor, team_color.x, team_color.y, team_color.z);
         }
+
+        if effect_hash.get_u64() == hash40("sys_flyroll_smoke") {
+            // <WuBor>
+            EffectModule::set_alpha_last(fighter.module_accessor, 0.6);
+            // </WuBor>
+        }
+
         WorkModule::set_int(fighter.module_accessor, effect_id as i32, effect_const.get_i32());
     }
     effect_id.into()

--- a/fighters/common/src/status/passive.rs
+++ b/fighters/common/src/status/passive.rs
@@ -10,14 +10,19 @@ unsafe extern "C" fn is_enable_passive(fighter: &mut L2CFighterCommon) -> L2CVal
 }
 
 pub unsafe extern "C" fn is_bad_passive(fighter: &mut L2CFighterCommon) -> L2CValue {
-    // let weight = WorkModule::get_param_float(fighter.module_accessor, hash40("weight"), 0);
-    // let damage = DamageModule::damage(fighter.module_accessor, 0);
-    // (weight + param::passive::invalid_passive_damage_add <= damage).into()
     fighter.clear_lua_stack();
-    lua_args!(fighter, hash40("reaction_frame"));
+    lua_args!(fighter, hash40("speed_vec_x"));
     sv_information::damage_log_value(fighter.lua_state_agent);
-    let reaction_frame = fighter.pop_lua_stack(1).get_f32();
-    (reaction_frame >= param::passive::invalid_passive_reaction).into()
+    let speed_vec_x = fighter.pop_lua_stack(1).get_f32();
+
+    fighter.clear_lua_stack();
+    lua_args!(fighter, hash40("speed_vec_y"));
+    sv_information::damage_log_value(fighter.lua_state_agent);
+    let speed_vec_y = fighter.pop_lua_stack(1).get_f32();
+
+    let speed_vector = sv_math::vec2_length(speed_vec_x, speed_vec_y);
+
+    (speed_vector >= param::damage::damage_speed_up_speed_max).into()
 }
 
 // #[skyline::hook(replace = L2CFighterCommon_sub_check_passive_button)]


### PR DESCRIPTION
# Changelog

The spinning knockback animation is now used when knockback speed exceeds 6.0.
Adjusts knockback aura effect to only show up when knockback speed exceeds 6.0.
Adjusts knockback aura effect size to be 0.65x the size.
Adjusts KB smoke to be 0.8x the size and have 0.6x opacity.