### PR TITLE
Bonker Time

### DIFF
--- a/fighters/mario/src/acmd.rs
+++ b/fighters/mario/src/acmd.rs
@@ -11,6 +11,8 @@ mod throws;
 mod escape;
 mod cliff;
 
+mod appeal;
+
 pub fn install(agent: &mut Agent) {
     dash::install(agent);
 
@@ -22,4 +24,6 @@ pub fn install(agent: &mut Agent) {
 
     escape::install(agent);
     cliff::install(agent);
+
+    appeal::install(agent);
 }

--- a/fighters/mario/src/acmd/aerials.rs
+++ b/fighters/mario/src/acmd/aerials.rs
@@ -13,11 +13,23 @@ unsafe extern "C" fn game_attackairf(agent: &mut L2CAgentBase) {
     }
     frame(agent.lua_state_agent, 19.0);
     if macros::is_excute(agent) {
-        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 13.0, 295, 65, 0, 24, 4.0, 0.0, 13.0, 8.0, Some(0.0), Some(3.0), Some(13.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_OBJECT);
+        let attrs = if VarModule::is_flag(agent.module_accessor, vars::mario::instance::flag::BONKER) {
+            ("collision_attr_coin", *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_COIN)
+        }
+        else {
+            ("collision_attr_normal", *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY)
+        };
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 13.0, 295, 65, 0, 24, 4.0, 0.0, 13.0, 8.0, Some(0.0), Some(3.0), Some(13.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new(attrs.0), attrs.1, attrs.2, *ATTACK_REGION_OBJECT);
     }
     frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
-        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 13.0, 295, 65, 0, 24, 4.0, 0.0, 3.0, 13.0, Some(0.0), Some(1.5), Some(4.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_OBJECT);
+        let attrs = if VarModule::is_flag(agent.module_accessor, vars::mario::instance::flag::BONKER) {
+            ("collision_attr_coin", *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_COIN)
+        }
+        else {
+            ("collision_attr_normal", *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY)
+        };
+        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 13.0, 295, 65, 0, 24, 4.0, 0.0, 3.0, 13.0, Some(0.0), Some(1.5), Some(4.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new(attrs.0), attrs.1, attrs.2, *ATTACK_REGION_OBJECT);
     }
     frame(agent.lua_state_agent, 22.0);
     if macros::is_excute(agent) {
@@ -38,7 +50,12 @@ unsafe extern "C" fn effect_attackairf(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         macros::EFFECT_FOLLOW_FLIP(agent, Hash40::new("sys_attack_arc_b"), Hash40::new("sys_attack_arc_b"), Hash40::new("top"), 0, 7, -1, -3, -11, -140, 1.5, true, *EF_FLIP_YZ);
         macros::LAST_EFFECT_SET_RATE(agent, 0.5);
-        macros::LAST_EFFECT_SET_COLOR(agent, 0.196, 0.196, 0.216);
+        if VarModule::is_flag(agent.module_accessor, vars::mario::instance::flag::BONKER) {
+            macros::LAST_EFFECT_SET_COLOR(agent, 0.9, 0.1, 0.1);
+        }
+        else {
+            macros::LAST_EFFECT_SET_COLOR(agent, 0.196, 0.196, 0.216);
+        }
     }
 }
 
@@ -196,7 +213,7 @@ unsafe extern "C" fn sound_attackairlw(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         macros::PLAY_SE(agent, Hash40::new("vc_mario_002"));
         macros::PLAY_SE(agent, Hash40::new("se_mario_attackair_l01"));
-    } 
+    }
 }
 
 unsafe extern "C" fn expression_attackairlw(agent: &mut L2CAgentBase) {

--- a/fighters/mario/src/acmd/appeal.rs
+++ b/fighters/mario/src/acmd/appeal.rs
@@ -1,0 +1,15 @@
+use super::*;
+
+unsafe extern "C" fn game_appealhi(agent: &mut L2CAgentBase) {
+    frame(agent.lua_state_agent, 30.0);
+    if macros::is_excute(agent) {
+        let is_bonker = VarModule::is_flag(agent.module_accessor, vars::mario::instance::flag::BONKER);
+        VarModule::set_flag(agent.module_accessor, vars::mario::instance::flag::BONKER, !is_bonker);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("game_appealhir", game_appealhi, Priority::Low);
+
+    agent.acmd("game_appealhil", game_appealhi, Priority::Low);
+}

--- a/fighters/mario/src/acmd/smashes.rs
+++ b/fighters/mario/src/acmd/smashes.rs
@@ -21,13 +21,25 @@ unsafe extern "C" fn game_attacks4(agent: &mut L2CAgentBase) {
     }
     frame(agent.lua_state_agent, 17.0);
     if macros::is_excute(agent) {
-        macros::ATTACK(agent, 0, 0, Hash40::new("haver"), 15.0, 361, 90, 0, 25, 2.0, 0.0, 0.0, -2.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_OBJECT);
-        macros::ATTACK(agent, 1, 0, Hash40::new("haver"), 15.0, 361, 90, 0, 25, 3.0, 5.0, 0.0, -3.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_OBJECT);
+        let attrs = if VarModule::is_flag(agent.module_accessor, vars::mario::instance::flag::BONKER) {
+            ("collision_attr_coin", *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_COIN)
+        }
+        else {
+            ("collision_attr_normal", *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY)
+        };
+        macros::ATTACK(agent, 0, 0, Hash40::new("haver"), 15.0, 361, 90, 0, 25, 2.0, 0.0, 0.0, -2.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new(attrs.0), attrs.1, attrs.2, *ATTACK_REGION_OBJECT);
+        macros::ATTACK(agent, 1, 0, Hash40::new("haver"), 15.0, 361, 90, 0, 25, 3.0, 5.0, 0.0, -3.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new(attrs.0), attrs.1, attrs.2, *ATTACK_REGION_OBJECT);
     }
     frame(agent.lua_state_agent, 21.0);
     if macros::is_excute(agent) {
-        macros::ATTACK(agent, 0, 0, Hash40::new("haver"), 18.0, 361, 90, 0, 25, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_OBJECT);
-        macros::ATTACK(agent, 1, 0, Hash40::new("haver"), 18.0, 361, 90, 0, 25, 4.0, 5.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_OBJECT);
+        let attrs = if VarModule::is_flag(agent.module_accessor, vars::mario::instance::flag::BONKER) {
+            ("collision_attr_coin", *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_COIN)
+        }
+        else {
+            ("collision_attr_normal", *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY)
+        };
+        macros::ATTACK(agent, 0, 0, Hash40::new("haver"), 18.0, 361, 90, 0, 25, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new(attrs.0), attrs.1, attrs.2, *ATTACK_REGION_OBJECT);
+        macros::ATTACK(agent, 1, 0, Hash40::new("haver"), 18.0, 361, 90, 0, 25, 4.0, 5.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new(attrs.0), attrs.1, attrs.2, *ATTACK_REGION_OBJECT);
     }
     wait(agent.lua_state_agent, 3.0);
     if macros::is_excute(agent) {
@@ -52,7 +64,12 @@ unsafe extern "C" fn effect_attacks4(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         macros::EFFECT_FOLLOW_FLIP(agent, Hash40::new("sys_attack_arc_b"), Hash40::new("sys_attack_arc_b"), Hash40::new("top"), -8, 6, 3, 0, -65, -90, 1.0, false, *EF_FLIP_BITCTRL);
         macros::LAST_EFFECT_SET_SCALE_W(agent, 1.28, 2.0, 1.12);
-        macros::LAST_EFFECT_SET_COLOR(agent, 0.196, 0.196, 0.216);
+        if VarModule::is_flag(agent.module_accessor, vars::mario::instance::flag::BONKER) {
+            macros::LAST_EFFECT_SET_COLOR(agent, 0.9, 0.1, 0.1);
+        }
+        else {
+            macros::LAST_EFFECT_SET_COLOR(agent, 0.196, 0.196, 0.216);
+        }
         macros::LAST_EFFECT_SET_RATE(agent, 0.5);
     }
     frame(agent.lua_state_agent, 20.0);
@@ -91,7 +108,12 @@ unsafe extern "C" fn sound_attacks4(agent: &mut L2CAgentBase) {
     }
     frame(agent.lua_state_agent, 21.0);
     if macros::is_excute(agent) {
-        macros::PLAY_SE(agent, Hash40::new("se_mario_manthit"));
+        if VarModule::is_flag(agent.module_accessor, vars::mario::instance::flag::BONKER) {
+            macros::PLAY_SE(agent, Hash40::new_raw(0x19e562e747));
+        }
+        else {
+            macros::PLAY_SE(agent, Hash40::new("se_mario_manthit"));
+        }
     }
 }
 


### PR DESCRIPTION
# Changelog

Allows Mario to use the fabled bonker. Press up taunt to swap Mario's hammer to the bonker. Doesn't have an effect or anything when you swap, but oh you'll know...