### PR TITLE
Final Smash Rebalance - Ryu and Ken

### DIFF
--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -796,6 +796,12 @@ pub mod ryu {
     pub const GUARD_SPECIAL_LW_KIND_REVERSAL : i32 = 0x1;
 }
 
+pub mod ryu_shinkuhadoken {
+    pub mod status {
+        pub const FINISH : i32 = 0x2;
+    }
+}
+
 pub mod ken {
     pub mod instance {
         pub mod flag {

--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -760,6 +760,7 @@ pub mod ryu {
         pub mod flag {
             pub const DENJIN_CHARGE : i32 = 0x0100;
             pub const DENJIN_RUSH_INHERIT : i32 = 0x0101;
+            pub const SKIP_FINAL_PROX_CHECK : i32 = 0x0102;
         }
         pub mod int {
             pub const DENJIN_EFF_HANDLE : i32 = 0x0100;
@@ -799,6 +800,8 @@ pub mod ken {
     pub mod instance {
         pub mod flag {
             pub const QUICK_STEP_INHERIT : i32 = 0x0100;
+
+            pub use super::super::super::ryu::instance::flag::SKIP_FINAL_PROX_CHECK;
         }
     }
     pub mod status {

--- a/fighters/ken/src/acmd.rs
+++ b/fighters/ken/src/acmd.rs
@@ -7,6 +7,8 @@ mod smashes;
 mod aerials;
 mod specials;
 
+mod r#final;
+
 mod escape;
 mod cliff;
 
@@ -17,6 +19,8 @@ pub fn install(agent: &mut Agent) {
     smashes::install(agent);
     aerials::install(agent);
     specials::install(agent);
+
+    r#final::install(agent);
 
     escape::install(agent);
     cliff::install(agent);

--- a/fighters/ken/src/acmd/final.rs
+++ b/fighters/ken/src/acmd/final.rs
@@ -1,0 +1,465 @@
+use super::*;
+
+unsafe extern "C" fn game_final(agent: &mut L2CAgentBase) {
+    frame(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        // new
+        macros::WHOLE_HIT(agent, *HIT_STATUS_XLU);
+        macros::CHECK_VALID_FINAL_START_CAMERA(agent, 0, 0, 20, 0, 0, 0);
+        macros::SLOW_OPPONENT(agent, 100.0, 55.0);
+    }
+    if !WorkModule::is_flag(agent.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_FINAL_START_CAMERA) {
+        frame(agent.lua_state_agent, 5.0);
+        if macros::is_excute(agent) {
+            macros::FT_SET_FINAL_FEAR_FACE(agent, 40);
+            macros::REQ_FINAL_START_CAMERA(agent, Hash40::new("d04final.nuanmb"), true);
+            macros::FT_START_CUTIN(agent);
+        }
+        if get_value_float(agent.lua_state_agent, *SO_VAR_FLOAT_LR) < 0.0 {
+            if macros::is_excute(agent) {
+                camera!(agent, *MA_MSC_CMD_CAMERA_CAM_OFFSET, 0, 0);
+                let scale = PostureModule::scale(agent.module_accessor);
+                macros::CAM_ZOOM_IN_arg5(agent, 3.0, 0.0, scale * 1.8, 0.0, 0.0);
+            }
+        }
+        else {
+            if macros::is_excute(agent) {
+                camera!(agent, *MA_MSC_CMD_CAMERA_CAM_OFFSET, 0, 0);
+                let scale = PostureModule::scale(agent.module_accessor);
+                macros::CAM_ZOOM_IN_arg5(agent, 3.0, 0.0, scale * 1.8, 0.0, 0.0);
+            }
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            macros::FT_START_CUTIN(agent);
+        }
+    }
+    frame(agent.lua_state_agent, 10.0);
+    macros::FT_MOTION_RATE(agent, 15.0);
+    // if macros::is_excute(agent) {
+    //     macros::ATTACK(agent, 0, 0, Hash40::new("top"), 1.0, 365, 100, 48, 17, 11.0, 0.0, 8.0, 8.0, None, None, None, 0.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, f32::NAN, 0.0, 0, false, false, false, true, false, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+    //     macros::ATTACK(agent, 1, 0, Hash40::new("top"), 1.0, 365, 100, 48, 17, 11.0, 0.0, 8.0, 8.0, None, None, None, 0.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, f32::NAN, 0.0, 0, false, false, false, true, false, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+    //     AttackModule::set_no_dead_all(agent.module_accessor, true, false);
+    //     AttackModule::set_no_uniq_effect_all(agent.module_accessor, true, false);
+    //     AttackModule::set_damage_shake_scale(agent.module_accessor, 0.18);
+    // }
+    // let scale = PostureModule::scale(agent.module_accessor);
+    // if scale >= 1.4 {
+    //     if macros::is_excute(agent) {
+    //         AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 15.0, y: 0.0}, 5, false);
+    //         AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 15.0, y: 0.0}, 5, false);
+    //     }
+    // }
+    // else if scale <= 0.5 {
+    //     if macros::is_excute(agent) {
+    //         AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 20.0, y: 0.0}, 2, false);
+    //         AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 20.0, y: 0.0}, 2, false);
+    //     }
+    // }
+    // else {
+    //     if macros::is_excute(agent) {
+    //         AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 13.0, y: 5.0}, 5, false);
+    //         AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 15.0, y: 4.0}, 10, false);
+    //     }
+    // }
+    // wait(agent.lua_state_agent, 1.0);
+    // if macros::is_excute(agent) {
+    //     AttackModule::clear_all(agent.module_accessor);
+    // }
+    frame(agent.lua_state_agent, 13.0);
+    macros::FT_MOTION_RATE(agent, 1.0);
+    frame(agent.lua_state_agent, 22.0);
+    frame(agent.lua_state_agent, 25.0);
+    game_finalsub(agent);
+    let scale = PostureModule::scale(agent.module_accessor);
+    if scale >= 1.4 {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 12.0, y: 5.0}, 13, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 15.0, y: 20.0}, 5, false);
+        }
+    }
+    else if scale <= 0.5{
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 28.0, y: 5.0}, 13, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 37.0, y: 10.0}, 15, false);
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 15.0, y: 1.0}, 9, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 19.0, y: 5.0}, 15, false);
+        }
+    }
+    wait(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+        HitModule::set_whole(agent.module_accessor, HitStatus(*HIT_STATUS_NORMAL), 0);
+    }
+    frame(agent.lua_state_agent, 40.0);
+    game_finalsub(agent);
+    let scale = PostureModule::scale(agent.module_accessor);
+    if scale >= 1.4 {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 13.0, y: 4.0}, 13, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 13.0, y: 7.0}, 15, false);
+        }
+    }
+    else if scale <= 0.5 {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 37.0, y: 4.0}, 13, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 37.0, y: 7.0}, 15, false);
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 20.0, y: 2.0}, 13, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 20.0, y: 4.0}, 15, false);
+        }
+    }
+    wait(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+    frame(agent.lua_state_agent, 55.0);
+    game_finalsub(agent);
+    let scale = PostureModule::scale(agent.module_accessor);
+    if scale >= 1.4 {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 13.0, y: 8.0}, 10, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 13.0, y: 10.0}, 15, false);
+        }
+    }
+    else if scale <= 0.5 {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 46.0, y: 8.0}, 10, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 46.0, y: 12.0}, 15, false);
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 22.0, y: 4.0}, 10, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 22.0, y: 7.0}, 15, false);
+        }
+    }
+    wait(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+    frame(agent.lua_state_agent, 64.0);
+    game_finalsub(agent);
+    let scale = PostureModule::scale(agent.module_accessor);
+    if scale >= 1.4 {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 14.0, y: 8.0}, 14, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 16.0, y: 10.0}, 15, false);
+        }
+    }
+    else if scale <= 0.5 {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 44.0, y: 8.0}, 14, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 52.0, y: 10.0}, 15, false);
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 22.0, y: 4.0}, 14, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 26.0, y: 5.0}, 15, false);
+        }
+    }
+    wait(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+    frame(agent.lua_state_agent, 76.0);
+    if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_LOCK_ATTACK);
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 4.0, 50, 95, 40, 0, 11.0, 0.0, 8.0, 8.0, Some(0.0), Some(10.0), Some(8.0), 3.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KEN_FINAL01, *ATTACK_REGION_KICK);
+        AttackModule::set_no_dead_all(agent.module_accessor, true, false);
+    }
+    wait(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+    if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_BRANCH_HIT);
+        SlowModule::clear_whole(agent.module_accessor);
+    }
+}
+
+unsafe extern "C" fn game_finalair(agent: &mut L2CAgentBase) {
+    frame(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        // new
+        macros::WHOLE_HIT(agent, *HIT_STATUS_XLU);
+        macros::CHECK_VALID_FINAL_START_CAMERA(agent, 0, 0, 20, 0, 0, 0);
+        macros::SLOW_OPPONENT(agent, 100.0, 55.0);
+    }
+    if !WorkModule::is_flag(agent.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_FINAL_START_CAMERA) {
+        frame(agent.lua_state_agent, 5.0);
+        if macros::is_excute(agent) {
+            macros::FT_SET_FINAL_FEAR_FACE(agent, 40);
+            macros::REQ_FINAL_START_CAMERA(agent, Hash40::new("d04final.nuanmb"), true);
+            macros::FT_START_CUTIN(agent);
+        }
+        if get_value_float(agent.lua_state_agent, *SO_VAR_FLOAT_LR) < 0.0 {
+            if macros::is_excute(agent) {
+                camera!(agent, *MA_MSC_CMD_CAMERA_CAM_OFFSET, 0, 0);
+                let scale = PostureModule::scale(agent.module_accessor);
+                macros::CAM_ZOOM_IN_arg5(agent, 3.0, 0.0, scale * 1.8, 0.0, 0.0);
+            }
+        }
+        else {
+            if macros::is_excute(agent) {
+                camera!(agent, *MA_MSC_CMD_CAMERA_CAM_OFFSET, 0, 0);
+                let scale = PostureModule::scale(agent.module_accessor);
+                macros::CAM_ZOOM_IN_arg5(agent, 3.0, 0.0, scale * 1.8, 0.0, 0.0);
+            }
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            macros::FT_START_CUTIN(agent);
+        }
+    }
+    frame(agent.lua_state_agent, 10.0);
+    macros::FT_MOTION_RATE(agent, 15.0);
+    // if macros::is_excute(agent) {
+    //     macros::ATTACK(agent, 0, 0, Hash40::new("top"), 1.0, 365, 100, 48, 17, 11.0, 0.0, 8.0, 8.0, None, None, None, 0.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, f32::NAN, 0.0, 0, false, false, false, true, false, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+    //     macros::ATTACK(agent, 1, 0, Hash40::new("top"), 1.0, 365, 100, 48, 17, 11.0, 0.0, 8.0, 8.0, None, None, None, 0.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, f32::NAN, 0.0, 0, false, false, false, true, false, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+    //     AttackModule::set_no_dead_all(agent.module_accessor, true, false);
+    //     AttackModule::set_no_uniq_effect_all(agent.module_accessor, true, false);
+    //     AttackModule::set_damage_shake_scale(agent.module_accessor, 0.18);
+    // }
+    // let scale = PostureModule::scale(agent.module_accessor);
+    // if scale >= 1.4 {
+    //     if macros::is_excute(agent) {
+    //         AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 15.0, y: 3.0}, 5, false);
+    //         AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 15.0, y: 3.0}, 5, false);
+    //     }
+    // }
+    // else if scale <= 0.5 {
+    //     if macros::is_excute(agent) {
+    //         AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 15.0, y: 1.0}, 3, false);
+    //         AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 15.0, y: 1.0}, 3, false);
+    //     }
+    // }
+    // else {
+    //     if macros::is_excute(agent) {
+    //         AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 12.0, y: 3.0}, 15, false);
+    //         AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 13.0, y: 6.0}, 15, false);
+    //     }
+    // }
+    // wait(agent.lua_state_agent, 1.0);
+    // if macros::is_excute(agent) {
+    //     AttackModule::clear_all(agent.module_accessor);
+    // }
+    frame(agent.lua_state_agent, 13.0);
+    macros::FT_MOTION_RATE(agent, 1.0);
+    frame(agent.lua_state_agent, 22.0);
+    frame(agent.lua_state_agent, 25.0);
+    game_finalsub(agent);
+    let scale = PostureModule::scale(agent.module_accessor);
+    if scale >= 1.4 {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 15.0, y: 12.0}, 15, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 15.0, y: 9.0}, 15, false);
+        }
+    }
+    else if scale <= 0.5{
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 37.0, y: 14.0}, 15, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 35.0, y: 9.0}, 15, false);
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 19.0, y: 13.0}, 15, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 19.0, y: 8.0}, 15, false);
+        }
+    }
+    wait(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+        HitModule::set_whole(agent.module_accessor, HitStatus(*HIT_STATUS_NORMAL), 0);
+    }
+    frame(agent.lua_state_agent, 40.0);
+    game_finalsub(agent);
+    let scale = PostureModule::scale(agent.module_accessor);
+    if scale >= 1.4 {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 15.0, y: 12.0}, 15, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 15.0, y: 9.0}, 15, false);
+        }
+    }
+    else if scale <= 0.5{
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 37.0, y: 14.0}, 15, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 35.0, y: 9.0}, 15, false);
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 19.0, y: 13.0}, 15, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 19.0, y: 8.0}, 15, false);
+        }
+    }
+    wait(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+    frame(agent.lua_state_agent, 55.0);
+    game_finalsub(agent);
+    let scale = PostureModule::scale(agent.module_accessor);
+    if scale >= 1.4 {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 15.0, y: 12.0}, 15, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 15.0, y: 9.0}, 15, false);
+        }
+    }
+    else if scale <= 0.5{
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 46.0, y: 14.0}, 15, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 46.0, y: 9.0}, 15, false);
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 22.0, y: 13.0}, 15, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 22.0, y: 8.0}, 15, false);
+        }
+    }
+    wait(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+    frame(agent.lua_state_agent, 64.0);
+    game_finalsub(agent);
+    let scale = PostureModule::scale(agent.module_accessor);
+    if scale >= 1.4 {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 15.0, y: 12.0}, 15, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 15.0, y: 9.0}, 15, false);
+        }
+    }
+    else if scale <= 0.5 {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 52.0, y: 14.0}, 15, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 52.0, y: 10.0}, 15, false);
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            AttackModule::set_vec_target_pos(agent.module_accessor, 0, Hash40::new("top"), &Vector2f{x: 26.0, y: 15.0}, 15, false);
+            AttackModule::set_vec_target_pos(agent.module_accessor, 1, Hash40::new("top"), &Vector2f{x: 26.0, y: 8.0}, 15, false);
+        }
+    }
+    wait(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+    frame(agent.lua_state_agent, 76.0);
+    if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_LOCK_ATTACK);
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 4.0, 50, 95, 40, 0, 11.0, 0.0, 8.0, 8.0, Some(0.0), Some(10.0), Some(8.0), 3.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KEN_FINAL01, *ATTACK_REGION_KICK);
+        AttackModule::set_no_dead_all(agent.module_accessor, true, false);
+    }
+    wait(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+    if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_BRANCH_HIT);
+        SlowModule::clear_whole(agent.module_accessor);
+    }
+}
+
+unsafe extern "C" fn game_finalsub(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        macros::CAM_ZOOM_OUT(agent);
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 3.2, 45, 150, 40, 0, 9.0, 0.0, 11.0, 5.0, Some(0.0), Some(11.0), Some(10.0), 1.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KEN_FINAL01, *ATTACK_REGION_KICK);
+        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 3.2, 45, 150, 40, 0, 9.0, 0.0, 11.0, 5.0, Some(0.0), Some(11.0), Some(10.0), 1.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KEN_FINAL01, *ATTACK_REGION_KICK);
+        AttackModule::set_no_dead_all(agent.module_accessor, true, false);
+        AttackModule::set_optional_hit_effect(agent.module_accessor, 0, Hash40::new("ken_final_shippu_hit_rush"));
+        AttackModule::set_optional_hit_effect(agent.module_accessor, 1, Hash40::new("ken_final_shippu_hit_rush"));
+    }
+}
+
+unsafe extern "C" fn game_final2(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+        macros::WHOLE_HIT(agent, *HIT_STATUS_XLU);
+    }
+    frame(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        macros::CHECK_VALID_FINAL_START_CAMERA(agent, 0, 0, 20, 0, 0, 0);
+        macros::SLOW_OPPONENT(agent, 100.0, 52.0);
+    }
+    if !WorkModule::is_flag(agent.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_FINAL_START_CAMERA) {
+        frame(agent.lua_state_agent, 10.0);
+        if macros::is_excute(agent) {
+            macros::FT_START_CUTIN(agent);
+            macros::FT_SET_FINAL_FEAR_FACE(agent, 40);
+            macros::REQ_FINAL_START_CAMERA(agent, Hash40::new("d04final2.nuanmb"), true);
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            let scale = PostureModule::scale(agent.module_accessor);
+            macros::CAM_ZOOM_IN_arg5(agent, 3.0, 0.0, 1.8 * scale, 0.0, 0.0);
+            macros::FT_START_CUTIN(agent);
+        }
+        frame(agent.lua_state_agent, 28.0);
+        if macros::is_excute(agent) {
+            macros::CAM_ZOOM_OUT(agent);
+        }
+    }
+    // let scale = PostureModule::scale(agent.module_accessor);
+    // if scale >= 1.4 {
+    //     if macros::is_excute(agent) {
+    //         macros::ATTACK(agent, 0, 0, Hash40::new("top"), 0.0, 366, 100, 140, 0, 35.0, 0.0, 5.0, -1.0, None, None, None, 0.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, true, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+    //     }
+    // }
+    // else if scale <= 0.5 {
+    //     if macros::is_excute(agent) {
+    //         macros::ATTACK(agent, 0, 0, Hash40::new("top"), 0.0, 366, 100, 22, 0, 35.0, 0.0, 5.0, -1.0, None, None, None, 0.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, true, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+    //     }
+    // }
+    // else {
+    //     if macros::is_excute(agent) {
+    //         macros::ATTACK(agent, 0, 0, Hash40::new("top"), 0.0, 366, 100, 70, 0, 35.0, 0.0, 5.0, -1.0, None, None, None, 0.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, true, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+    //     }
+    // }
+    // wait(agent.lua_state_agent, 10.0);
+    // if macros::is_excute(agent) {
+    //     AttackModule::clear(agent.module_accessor, 0, false);
+    // }
+    frame(agent.lua_state_agent, 48.0);
+    if macros::is_excute(agent) {
+        SlowModule::set_whole(agent.module_accessor, 2, 0);
+    }
+    wait(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        SlowModule::clear_whole(agent.module_accessor);
+    }
+    frame(agent.lua_state_agent, 52.0);
+    if macros::is_excute(agent) {
+        macros::SA_SET(agent, *SITUATION_KIND_AIR);
+        camera!(agent, *MA_MSC_CMD_CAMERA_CAM_RECT, 40, -40, 20, 0);
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_ADJUST_SHINRYUKEN_POS);
+    }
+    frame(agent.lua_state_agent, 90.0);
+    if macros::is_excute(agent) {
+        HitModule::set_whole(agent.module_accessor, HitStatus(*HIT_STATUS_NORMAL), 0);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("game_final", game_final, Priority::Low);
+
+    agent.acmd("game_finalair", game_finalair, Priority::Low);
+
+    agent.acmd("game_final2", game_final2, Priority::Low);
+
+    agent.acmd("game_final2air", game_final2, Priority::Low);
+}

--- a/fighters/ken/src/acmd/specials.rs
+++ b/fighters/ken/src/acmd/specials.rs
@@ -54,6 +54,7 @@ unsafe extern "C" fn game_specialn2start(agent: &mut L2CAgentBase) {
     macros::FT_MOTION_RATE(agent, 1.0);
     frame(agent.lua_state_agent, 21.0);
     if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
         macros::ATTACK(agent, 0, 0, Hash40::new("top"), 6.0, 80, 100, 50, 0, 3.0, 0.0, 12.5, 3.6, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
         macros::ATTACK(agent, 1, 0, Hash40::new("top"), 6.0, 90, 100, 50, 0, 3.0, 0.0, 15.5, 8.8, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
         AttackModule::set_add_reaction_frame_revised(agent.module_accessor, 0, 5.0, false);
@@ -62,6 +63,8 @@ unsafe extern "C" fn game_specialn2start(agent: &mut L2CAgentBase) {
     wait(agent.lua_state_agent, 4.0);
     if macros::is_excute(agent) {
         AttackModule::clear_all(agent.module_accessor);
+        WorkModule::off_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
+        WorkModule::off_flag(agent.module_accessor, 0x200000E9);
     }
     frame(agent.lua_state_agent, 28.0);
     if macros::is_excute(agent) {
@@ -137,6 +140,7 @@ unsafe extern "C" fn expression_specialn2start(agent: &mut L2CAgentBase) {
 unsafe extern "C" fn game_specialn2lw(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 6.0);
     if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
         macros::ATTACK(agent, 0, 0, Hash40::new("top"), 6.0, 75, 50, 0, 40, 2.8, 0.0, 8.0, 3.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
         macros::ATTACK(agent, 1, 0, Hash40::new("top"), 6.0, 75, 50, 0, 40, 2.8, 0.0, 6.0, 6.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
         macros::ATTACK(agent, 2, 0, Hash40::new("top"), 6.0, 75, 50, 0, 40, 3.0, 0.0, 4.0, 9.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
@@ -144,6 +148,10 @@ unsafe extern "C" fn game_specialn2lw(agent: &mut L2CAgentBase) {
     wait(agent.lua_state_agent, 4.0);
     if macros::is_excute(agent) {
         AttackModule::clear_all(agent.module_accessor);
+    }
+    wait(agent.lua_state_agent, 4.0);
+    if macros::is_excute(agent) {
+        WorkModule::off_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
     }
 }
 
@@ -189,12 +197,17 @@ unsafe extern "C" fn expression_specialn2lw(agent: &mut L2CAgentBase) {
 unsafe extern "C" fn game_specialn2hi(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 15.0);
     if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
         macros::ATTACK(agent, 0, 0, Hash40::new("footr"), 10.0, 361, 60, 0, 60, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 5, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
         macros::ATTACK(agent, 1, 0, Hash40::new("kneer"), 10.0, 361, 60, 0, 60, 2.8, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 5, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
     }
     wait(agent.lua_state_agent, 5.0);
     if macros::is_excute(agent) {
         AttackModule::clear_all(agent.module_accessor);
+    }
+    wait(agent.lua_state_agent, 4.0);
+    if macros::is_excute(agent) {
+        WorkModule::off_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
     }
 }
 
@@ -252,12 +265,17 @@ unsafe extern "C" fn game_specialn2s(agent: &mut L2CAgentBase) {
     macros::FT_MOTION_RATE(agent, 1.0);
     frame(agent.lua_state_agent, 8.0);
     if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
         macros::ATTACK(agent, 0, 0, Hash40::new("top"), 8.0, 45, 80, 0, 80, 3.0, 0.0, 12.5, 3.6, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
         macros::ATTACK(agent, 1, 0, Hash40::new("top"), 8.0, 45, 80, 0, 80, 3.0, 0.0, 15.5, 8.8, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
     }
     wait(agent.lua_state_agent, 4.0);
     if macros::is_excute(agent) {
         AttackModule::clear_all(agent.module_accessor);
+    }
+    wait(agent.lua_state_agent, 4.0);
+    if macros::is_excute(agent) {
+        WorkModule::off_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
     }
 }
 
@@ -353,6 +371,9 @@ unsafe extern "C" fn game_specialairn2(agent: &mut L2CAgentBase) {
     //     macros::FT_MOTION_RATE(agent, 7.0 / 4.0);
     // }
     frame(agent.lua_state_agent, 23.0);
+    if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
+    }
     let strength = WorkModule::get_int(agent.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_COMMON_INT_STRENGTH);
     if VarModule::is_flag(agent.module_accessor, vars::ken::status::flag::QUICK_STEP_INHERITED)
     || strength == *FIGHTER_RYU_STRENGTH_S {

--- a/fighters/ken/src/acmd/specials.rs
+++ b/fighters/ken/src/acmd/specials.rs
@@ -1624,6 +1624,7 @@ unsafe extern "C" fn game_speciallw(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 10.0);
     if macros::is_excute(agent) {
         VarModule::on_flag(agent.module_accessor, vars::ken::status::flag::SPECIAL_LW_RESET_GRAVITY);
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
         macros::ATTACK(agent, 0, 0, Hash40::new("top"), 10.0, 45, 10, 0, 70, 3.5, 0.0, 9.5, 10.0, Some(0.0), Some(9.5), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 15, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
     }
     frame(agent.lua_state_agent, 14.0);

--- a/fighters/ken/src/agent_init.rs
+++ b/fighters/ken/src/agent_init.rs
@@ -7,6 +7,28 @@ extern "C" {
 
 pub unsafe extern "C" fn ken_check_special_command(fighter: &mut L2CFighterCommon) -> L2CValue {
     let cat4 = fighter.global_table[CMD_CAT4].get_i32();
+    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_FINAL) {
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SUPER_SPECIAL_COMMAND != 0 {
+            fighter.clear_lua_stack();
+            lua_args!(fighter, Hash40::new_raw(0x229a8a3811));
+            sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+            if fighter.pop_lua_stack(1).get_bool() {
+                VarModule::on_flag(fighter.module_accessor, vars::ken::instance::flag::SKIP_FINAL_PROX_CHECK);
+                fighter.change_status(FIGHTER_RYU_STATUS_KIND_FINAL2.into(), true.into());
+                return true.into();
+            }
+        }
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SUPER_SPECIAL2_COMMAND != 0 {
+            fighter.clear_lua_stack();
+            lua_args!(fighter, Hash40::new_raw(0x229a8a3811));
+            sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+            if fighter.pop_lua_stack(1).get_bool() {
+                VarModule::on_flag(fighter.module_accessor, vars::ken::instance::flag::SKIP_FINAL_PROX_CHECK);
+                fighter.change_status(FIGHTER_STATUS_KIND_FINAL.into(), true.into());
+                return true.into();
+            }
+        }
+    }
     if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N2_COMMAND != 0
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N2_COMMAND)
     && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[CHECK_SPECIAL_S_UNIQ].clone()).get_bool() {

--- a/fighters/ken/src/lib.rs
+++ b/fighters/ken/src/lib.rs
@@ -20,6 +20,7 @@ mod frame;
 mod agent_init;
 
 mod hadoken;
+mod shinryuken;
 
 pub fn install() {
     let agent = &mut Agent::new("ken");
@@ -30,4 +31,5 @@ pub fn install() {
     agent.install();
 
     hadoken::install();
+    shinryuken::install();
 }

--- a/fighters/ken/src/shinryuken/acmd.rs
+++ b/fighters/ken/src/shinryuken/acmd.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+unsafe extern "C" fn game_final(agent: &mut L2CAgentBase) {
+    // if macros::is_excute(agent) {
+    //     macros::ATTACK(agent, 1, 0, Hash40::new("top"), 1.3, 110, 120, 130, 0, 11.0, 0.0, -20.0, 0.0, Some(0.0), Some(80.0), Some(0.0), 0.4, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, f32::NAN, 0.0, 2, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+    //     macros::ATTACK(agent, 0, 0, Hash40::new("top"), 1.3, 367, 100, 100, 0, 11.0, 0.0, 80.0, 0.0, None, None, None, 0.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, f32::NAN, 0.0, 2, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+    // }
+    frame(agent.lua_state_agent, 52.0);
+    if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *WEAPON_KEN_SHINRYUKEN_INSTANCE_WORK_ID_FLAG_ADD_ATTACK);
+        macros::ATTACK(agent, 3, 0, Hash40::new("top"), 2.0, 110, 85, 70, 0, 11.0, 0.0, -20.0, 0.0, Some(0.0), Some(80.0), Some(0.0), 0.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+        macros::ATTACK(agent, 2, 0, Hash40::new("top"), 2.0, 367, 100, 100, 0, 11.0, 0.0, 80.0, 0.0, None, None, None, 0.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+    }
+    frame(agent.lua_state_agent, 90.0);
+    if macros::is_excute(agent) {
+        WorkModule::off_flag(agent.module_accessor, *WEAPON_KEN_SHINRYUKEN_INSTANCE_WORK_ID_FLAG_ADD_ATTACK);
+        macros::ATTACK(agent, 3, 0, Hash40::new("top"), 13.0, 70, 63, 0, 105, 11.0, 0.0, -20.0, 0.0, Some(0.0), Some(80.0), Some(0.0), 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+        macros::ATTACK(agent, 2, 0, Hash40::new("top"), 13.0, 70, 63, 0, 105, 11.0, 0.0, 80.0, 0.0, None, None, None, 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+    }
+    wait(agent.lua_state_agent, 3.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("game_final", game_final, Priority::Low);
+}

--- a/fighters/ken/src/shinryuken/mod.rs
+++ b/fighters/ken/src/shinryuken/mod.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+mod acmd;
+
+pub fn install() {
+    let agent = &mut Agent::new("ken_shinryuken");
+    acmd::install(agent);
+    agent.install();
+}

--- a/fighters/ken/src/status.rs
+++ b/fighters/ken/src/status.rs
@@ -19,6 +19,8 @@ mod special_hi;
 
 mod special_lw;
 
+mod r#final;
+
 pub fn install(agent: &mut Agent) {
     dash_back::install(agent);
 
@@ -38,4 +40,6 @@ pub fn install(agent: &mut Agent) {
     special_hi::install(agent);
 
     special_lw::install(agent);
+
+    r#final::install(agent);
 }

--- a/fighters/ken/src/status/attack_command1.rs
+++ b/fighters/ken/src/status/attack_command1.rs
@@ -1,10 +1,5 @@
 use super::*;
 
-extern "C" {
-    #[link_name = "ryu_final_hit_cancel"]
-    pub fn ryu_final_hit_cancel(fighter: &mut L2CFighterCommon, situation: L2CValue) -> L2CValue;
-}
-
 unsafe extern "C" fn ken_attack_command1_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
     let attr = if VarModule::is_flag(fighter.module_accessor, vars::ken::instance::flag::QUICK_STEP_INHERIT) {
         0
@@ -104,13 +99,6 @@ unsafe extern "C" fn ken_attack_command1_substatus(fighter: &mut L2CFighterCommo
 unsafe extern "C" fn ken_attack_command1_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
     if CancelModule::is_enable_cancel(fighter.module_accessor) {
         if fighter.sub_wait_ground_check_common(false.into()).get_bool() {
-            return 1.into();
-        }
-    }
-    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL)
-    && AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_SHIELD | *COLLISION_KIND_MASK_HIT) {
-        let sitation = fighter.global_table[SITUATION_KIND].get_i32();
-        if ryu_final_hit_cancel(fighter, sitation.into()).get_bool() {
             return 1.into();
         }
     }

--- a/fighters/ken/src/status/final/final1.rs
+++ b/fighters/ken/src/status/final/final1.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+unsafe extern "C" fn ken_final_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if !VarModule::is_flag(fighter.module_accessor, vars::ken::instance::flag::SKIP_FINAL_PROX_CHECK) {
+        fighter.sub_status_pre_FinalCommon();
+        fighter.clear_lua_stack();
+        lua_args!(fighter, Hash40::new_raw(0x20e3e3c94b));
+        sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+        if fighter.pop_lua_stack(1).get_bool() {
+            StatusModule::set_status_kind_interrupt(fighter.module_accessor, *FIGHTER_RYU_STATUS_KIND_FINAL2);
+            return 1.into();
+        }
+    }
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_NONE),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_NONE as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
+        false,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_DISABLE,
+        false,
+        false,
+        false,
+        (
+            *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_FINAL|
+            *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK |
+            *FIGHTER_LOG_MASK_FLAG_ACTION_TRIGGER_ON
+        ) as u64,
+        (
+            *FIGHTER_STATUS_ATTR_DISABLE_ITEM_INTERRUPT |
+            *FIGHTER_STATUS_ATTR_DISABLE_TURN_DAMAGE |
+            *FIGHTER_STATUS_ATTR_FINAL
+        ) as u32,
+        *FIGHTER_POWER_UP_ATTACK_BIT_FINAL as u32,
+        0
+    );
+    0.into()
+}
+
+unsafe extern "C" fn ken_final_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    VarModule::off_flag(fighter.module_accessor, vars::ken::instance::flag::SKIP_FINAL_PROX_CHECK);
+
+    WorkModule::set_int(fighter.module_accessor, 0x50000000, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_INT_TARGET_BATTLE_OBJECT_ID);
+    WorkModule::set_float(fighter.module_accessor, f32::MAX, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLOAT_DIST_MIN);
+
+    let kinetic = if StatusModule::situation_kind(fighter.module_accessor) == *SITUATION_KIND_GROUND {
+        *FIGHTER_KINETIC_TYPE_MOTION
+    }
+    else {
+        *FIGHTER_KINETIC_TYPE_MOTION_AIR
+    };
+    KineticModule::change_kinetic(fighter.module_accessor, kinetic);
+
+    let final_shake_scale = WorkModule::get_param_float(fighter.module_accessor, hash40("param_private"), hash40("final_shake_scale"));
+    AttackModule::set_damage_shake_scale(fighter.module_accessor, final_shake_scale);
+
+    let color = FighterUtil::renderer_get_clear_color();
+    let rate = FighterUtil::renderer_get_color_rate();
+    WorkModule::set_float(fighter.module_accessor, color.x, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLOAT_ORIGINAL_BG_COLOR_R);
+    WorkModule::set_float(fighter.module_accessor, color.y, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLOAT_ORIGINAL_BG_COLOR_G);
+    WorkModule::set_float(fighter.module_accessor, color.z, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLOAT_ORIGINAL_BG_COLOR_B);
+    WorkModule::set_float(fighter.module_accessor, color.w, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLOAT_ORIGINAL_BG_COLOR_A);
+    WorkModule::set_float(fighter.module_accessor, rate, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLOAT_ORIGINAL_COLOR_RATE);
+
+    WorkModule::set_int(fighter.module_accessor, 0, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_INT_INVISIBLE_STAGE_TIME);
+    WorkModule::set_flag(fighter.module_accessor, false, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_INVISIBLE_STAGE);
+
+    ken_final_set_area(fighter, false.into());
+
+    ModelModule::disable_gold_eye(fighter.module_accessor);
+
+    notify_event_msc_cmd!(fighter, Hash40::new_raw(0x201bc9217c));
+
+    // HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    let mot = if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        "final"
+    }
+    else {
+        "final_air"
+    };
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new(mot),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    ItemModule::set_change_status_event(fighter.module_accessor, false);
+
+    let main_loop = smashline::api::get_target_function("lua2cpp_ken.nrs", 0x42400).unwrap();
+    fighter.sub_shift_status_main(L2CValue::Ptr(main_loop as *const () as _))
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Pre, *FIGHTER_STATUS_KIND_FINAL, ken_final_pre);
+    agent.status(Main, *FIGHTER_STATUS_KIND_FINAL, ken_final_main);
+}

--- a/fighters/ken/src/status/final/final1_hit.rs
+++ b/fighters/ken/src/status/final/final1_hit.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+unsafe extern "C" fn ken_final_hit_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let camera_func : fn(fighter: &mut L2CFighterCommon, cam_const: L2CValue) = std::mem::transmute(smashline::api::get_target_function("lua2cpp_ken.nrs", 0x40590).unwrap());
+    camera_func(fighter, FIGHTER_RYU_FINAL_CAMERA_OFFSET_1.into());
+
+    let final_shake_scale2 = WorkModule::get_param_float(fighter.module_accessor, hash40("param_private"), hash40("final_shake_scale2"));
+    AttackModule::set_damage_shake_scale(fighter.module_accessor, final_shake_scale2);
+
+    MotionModule::set_trans_move_speed_no_scale(fighter.module_accessor, false);
+
+    ken_final_set_area(fighter, false.into());
+
+    // HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    let mut zoom = 1.1;
+    if PostureModule::scale(fighter.module_accessor) > 1.0 {
+        zoom *= PostureModule::scale(fighter.module_accessor);
+    }
+    CameraModule::zoom_in(
+        fighter.module_accessor,
+        5,
+        0,
+        zoom,
+        &Vector2f{x: 0.0, y: 0.0},
+        true
+    );
+
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_NO_DEAD);
+
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("final_hit"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    let main_loop = smashline::api::get_target_function("lua2cpp_ken.nrs", 0x40b30).unwrap();
+    fighter.sub_shift_status_main(L2CValue::Ptr(main_loop as *const () as _))
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_RYU_STATUS_KIND_FINAL_HIT, ken_final_hit_main);
+}

--- a/fighters/ken/src/status/final/final1_jump.rs
+++ b/fighters/ken/src/status/final/final1_jump.rs
@@ -1,0 +1,16 @@
+use super::*;
+
+unsafe extern "C" fn ken_final_jump_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    AttackModule::set_damage_shake_scale(fighter.module_accessor, 1.0);
+
+    ken_final_set_area(fighter, false.into());
+
+    // HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    let main_loop = smashline::api::get_target_function("lua2cpp_ken.nrs", 0x42100).unwrap();
+    fighter.sub_shift_status_main(L2CValue::Ptr(main_loop as *const () as _))
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_RYU_STATUS_KIND_FINAL_JUMP, ken_final_jump_main);
+}

--- a/fighters/ken/src/status/final/final2.rs
+++ b/fighters/ken/src/status/final/final2.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+unsafe extern "C" fn ken_final2_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    VarModule::off_flag(fighter.module_accessor, vars::ken::instance::flag::SKIP_FINAL_PROX_CHECK);
+
+    let kinetic = if StatusModule::situation_kind(fighter.module_accessor) == *SITUATION_KIND_GROUND {
+        *FIGHTER_KINETIC_TYPE_MOTION
+    }
+    else {
+        *FIGHTER_KINETIC_TYPE_MOTION_AIR
+    };
+    KineticModule::change_kinetic(fighter.module_accessor, kinetic);
+
+    let final_shake_scale = WorkModule::get_param_float(fighter.module_accessor, hash40("param_private"), hash40("final_shake_scale"));
+    AttackModule::set_damage_shake_scale(fighter.module_accessor, final_shake_scale);
+
+    let color = FighterUtil::renderer_get_clear_color();
+    let rate = FighterUtil::renderer_get_color_rate();
+    WorkModule::set_float(fighter.module_accessor, color.x, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLOAT_ORIGINAL_BG_COLOR_R);
+    WorkModule::set_float(fighter.module_accessor, color.y, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLOAT_ORIGINAL_BG_COLOR_G);
+    WorkModule::set_float(fighter.module_accessor, color.z, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLOAT_ORIGINAL_BG_COLOR_B);
+    WorkModule::set_float(fighter.module_accessor, color.w, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLOAT_ORIGINAL_BG_COLOR_A);
+    WorkModule::set_float(fighter.module_accessor, rate, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLOAT_ORIGINAL_COLOR_RATE);
+
+    WorkModule::set_int(fighter.module_accessor, 0, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_INT_INVISIBLE_STAGE_TIME);
+    WorkModule::set_flag(fighter.module_accessor, false, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_INVISIBLE_STAGE);
+
+    ken_final_set_area(fighter, false.into());
+
+    ModelModule::disable_gold_eye(fighter.module_accessor);
+
+    notify_event_msc_cmd!(fighter, Hash40::new_raw(0x201bc9217c));
+
+    // HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    let mot = if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        "final2"
+    }
+    else {
+        "final2_air"
+    };
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new(mot),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    ItemModule::set_change_status_event(fighter.module_accessor, false);
+
+    ArticleModule::generate_article(fighter.module_accessor, *FIGHTER_KEN_GENERATE_ARTICLE_SHINRYUKEN, false, -1);
+
+    let main_loop = smashline::api::get_target_function("lua2cpp_ken.nrs", 0x3e630).unwrap();
+    fighter.sub_shift_status_main(L2CValue::Ptr(main_loop as *const () as _))
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_RYU_STATUS_KIND_FINAL2, ken_final2_main);
+}

--- a/fighters/ken/src/status/final/final2_air_end.rs
+++ b/fighters/ken/src/status/final/final2_air_end.rs
@@ -1,0 +1,39 @@
+use super::*;
+
+unsafe extern "C" fn ken_final2_air_end_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("final2_air_end"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    fighter.sub_shift_status_main(L2CValue::Ptr(ken_final2_air_end_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn ken_final2_air_end_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.sub_transition_group_check_air_cliff().get_bool() {
+        return 1.into();
+    }
+
+    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        fighter.change_status(FIGHTER_RYU_STATUS_KIND_FINAL2_LANDING.into(), false.into());
+        return 0.into();
+    }
+
+    if MotionModule::is_end(fighter.module_accessor) {
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+    }
+
+    0.into()
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_RYU_STATUS_KIND_FINAL2_AIR_END, ken_final2_air_end_main);
+}

--- a/fighters/ken/src/status/final/final2_fall.rs
+++ b/fighters/ken/src/status/final/final2_fall.rs
@@ -1,0 +1,54 @@
+use super::*;
+
+unsafe extern "C" fn ken_final2_fall_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("final2_fall"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    let final2_fall_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("param_private"), hash40("final2_fall_frame"));
+    WorkModule::set_int(fighter.module_accessor, final2_fall_frame, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_INT_COUNTER);
+
+    fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(ken_final2_fall_substatus as *const () as _));
+
+    let gravity = KineticModule::get_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+
+    let final2_fall_brake_y_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_private"), hash40("final2_fall_brake_y_mul"));
+    lua_bind::FighterKineticEnergyGravity::set_brake(gravity as *mut smash::app::FighterKineticEnergyGravity, final2_fall_brake_y_mul);
+
+    let air_speed_y_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_y_stable"), 0);
+    let air_speed_y_limit = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("air_speed_y_limit"));
+    let final2_air_speed_y_stable_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_private"), hash40("final2_air_speed_y_stable_mul"));
+    lua_bind::FighterKineticEnergyGravity::set_stable_speed(
+        gravity as *mut smash::app::FighterKineticEnergyGravity,
+        air_speed_y_stable * final2_air_speed_y_stable_mul
+    );
+    lua_bind::FighterKineticEnergyGravity::set_limit_speed(
+        gravity as *mut smash::app::FighterKineticEnergyGravity,
+        air_speed_y_limit * final2_air_speed_y_stable_mul
+    );
+
+    ken_final_set_area(fighter, false.into());
+
+    let main_loop = smashline::api::get_target_function("lua2cpp_ken.nrs", 0x3e1f0).unwrap();
+    fighter.sub_shift_status_main(L2CValue::Ptr(main_loop as *const () as _))
+}
+
+unsafe extern "C" fn ken_final2_fall_substatus(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
+    if param_1.get_bool() {
+        WorkModule::dec_int(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_INT_COUNTER);
+    }
+    0.into()
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_RYU_STATUS_KIND_FINAL2_FALL, ken_final2_fall_main);
+}

--- a/fighters/ken/src/status/final/final2_landing.rs
+++ b/fighters/ken/src/status/final/final2_landing.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+unsafe extern "C" fn ken_final2_landing_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    let end_frame = MotionModule::end_frame_from_hash(fighter.module_accessor, Hash40::new("final2_landing"));
+    let final2_landing_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("param_private"), hash40("final2_landing_frame")) as f32;
+    let rate = end_frame / final2_landing_frame;
+
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("final2_landing"),
+        0.0,
+        rate,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    let main_loop = smashline::api::get_target_function("lua2cpp_ken.nrs", 0x3de90).unwrap();
+    fighter.sub_shift_status_main(L2CValue::Ptr(main_loop as *const () as _))
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_RYU_STATUS_KIND_FINAL2_LANDING, ken_final2_landing_main);
+}

--- a/fighters/ken/src/status/final/mod.rs
+++ b/fighters/ken/src/status/final/mod.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+pub unsafe extern "C" fn ken_final_set_area(fighter: &mut L2CFighterCommon, enable: L2CValue) {
+    for x in 0..*FIGHTER_AREA_KIND_NUM {
+        if x != *FIGHTER_AREA_KIND_WIND && x != *FIGHTER_AREA_KIND_WIND_RAD {
+            AreaModule::enable_area(fighter.module_accessor, x, enable.get_bool(), -1);
+        }
+    }
+}
+
+mod final1;
+mod final1_jump;
+mod final1_hit;
+
+mod final2;
+mod final2_fall;
+mod final2_landing;
+mod final2_air_end;
+
+pub fn install(agent: &mut Agent) {
+    final1::install(agent);
+    final1_jump::install(agent);
+    final1_hit::install(agent);
+
+    final2::install(agent);
+    final2_fall::install(agent);
+    final2_landing::install(agent);
+    final2_air_end::install(agent);
+}

--- a/fighters/ken/src/status/special_n2.rs
+++ b/fighters/ken/src/status/special_n2.rs
@@ -1,10 +1,5 @@
 use super::*;
 
-extern "C" {
-    #[link_name = "ryu_final_hit_cancel"]
-    pub fn ryu_final_hit_cancel(fighter: &mut L2CFighterCommon, situation: L2CValue) -> L2CValue;
-}
-
 unsafe extern "C" fn ken_special_n2_command_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
     StatusModule::init_settings(
         fighter.module_accessor,
@@ -137,13 +132,6 @@ unsafe extern "C" fn ken_special_n2_substatus(fighter: &mut L2CFighterCommon, pa
 unsafe extern "C" fn ken_special_n2_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
     if CancelModule::is_enable_cancel(fighter.module_accessor) {
         if fighter.sub_air_check_fall_common().get_bool() {
-            return 1.into();
-        }
-    }
-    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL)
-    && AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_SHIELD | *COLLISION_KIND_MASK_HIT) {
-        let sitation = fighter.global_table[SITUATION_KIND].get_i32();
-        if ryu_final_hit_cancel(fighter, sitation.into()).get_bool() {
             return 1.into();
         }
     }

--- a/fighters/ryu/src/acmd.rs
+++ b/fighters/ryu/src/acmd.rs
@@ -7,6 +7,8 @@ mod smashes;
 mod aerials;
 mod specials;
 
+mod r#final;
+
 mod escape;
 mod cliff;
 
@@ -17,6 +19,8 @@ pub fn install(agent: &mut Agent) {
     smashes::install(agent);
     aerials::install(agent);
     specials::install(agent);
+
+    r#final::install(agent);
 
     escape::install(agent);
     cliff::install(agent);

--- a/fighters/ryu/src/acmd/final.rs
+++ b/fighters/ryu/src/acmd/final.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+unsafe extern "C" fn game_final(agent: &mut L2CAgentBase) {
+    frame(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        macros::WHOLE_HIT(agent, *HIT_STATUS_XLU);
+        macros::CHECK_VALID_FINAL_START_CAMERA(agent, 0, 7, 20, 0, 0, 0);
+        macros::SLOW_OPPONENT(agent, 100.0, 50.0);
+    }
+    if !WorkModule::is_flag(agent.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_FINAL_START_CAMERA) {
+        frame(agent.lua_state_agent, 10.0);
+        if macros::is_excute(agent) {
+            macros::FT_SET_FINAL_FEAR_FACE(agent, 40);
+            macros::REQ_FINAL_START_CAMERA(agent, Hash40::new("d04final.nuanmb"), true);
+            macros::FT_START_CUTIN(agent);
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            let scale = PostureModule::scale(agent.module_accessor);
+            macros::CAM_ZOOM_IN_arg5(agent, 3.0, 0.0, scale * 1.8, 0.0, 0.0);
+            macros::FT_START_CUTIN(agent);
+        }
+        frame(agent.lua_state_agent, 28.0);
+        if macros::is_excute(agent) {
+            macros::CAM_ZOOM_OUT(agent);
+        }
+    }
+    // frame(agent.lua_state_agent, 30.0);
+    // if macros::is_excute(agent) {
+    //     macros::ATTACK(agent, 0, 0, Hash40::new("top"), 1.0, 60, 90, 0, 50, 8.0, 0.0, 5.0, 8.0, Some(0.0), Some(9.5), Some(8.0), 1.0, 0.1, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+    //     AttackModule::set_no_dead_all(agent.module_accessor, true, false);
+    //     AttackModule::set_damage_shake_scale(agent.module_accessor, 0.18);
+    // }
+    // wait(agent.lua_state_agent, 1.0);
+    // if macros::is_excute(agent) {
+    //     AttackModule::clear_all(agent.module_accessor);
+    // }
+    frame(agent.lua_state_agent, 50.0);
+    if macros::is_excute(agent) {
+        SlowModule::set_whole(agent.module_accessor, 2, 0);
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_LOCK_ATTACK);
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 10.0, 80, 95, 0, 50, 8.0, 0.0, 5.0, 10.0, Some(0.0), Some(9.5), Some(10.0), 2.6, 0.1, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_RYU_FINAL01, *ATTACK_REGION_PUNCH);
+        AttackModule::set_no_dead_all(agent.module_accessor, true, false);
+    }
+    wait(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_BRANCH_HIT);
+        SlowModule::clear_whole(agent.module_accessor);
+    }
+    frame(agent.lua_state_agent, 52.0);
+    if macros::is_excute(agent) {
+        macros::ATTACK(agent, 0, 0, Hash40::new("handr"), 2.0, 367, 100, 120, 0, 3.5, 0.0, 0.0, 0.0, None, None, None, 1.0, 0.1, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 2, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_RYU_PUNCH, *ATTACK_REGION_PUNCH);
+        AttackModule::set_no_dead_all(agent.module_accessor, true, false);
+    }
+    wait(agent.lua_state_agent, 10.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+        macros::ATTACK(agent, 0, 0, Hash40::new("handr"), 5.0, 80, 120, 0, 40, 4.5, 0.0, 0.0, 0.0, None, None, None, 1.0, 0.1, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_RYU_PUNCH, *ATTACK_REGION_PUNCH);
+        AttackModule::set_no_dead_all(agent.module_accessor, true, false);
+    }
+    wait(agent.lua_state_agent, 2.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+}
+
+unsafe extern "C" fn game_final2(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        macros::WHOLE_HIT(agent, *HIT_STATUS_XLU);
+        macros::SLOW_OPPONENT(agent, 100.0, 60.0);
+        macros::CHECK_VALID_FINAL_START_CAMERA(agent, 0, 7, 20, 0, 0, 0);
+    }
+    if !WorkModule::is_flag(agent.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_FINAL_START_CAMERA) {
+        frame(agent.lua_state_agent, 10.0);
+        if macros::is_excute(agent) {
+            macros::FT_SET_FINAL_FEAR_FACE(agent, 50);
+            macros::REQ_FINAL_START_CAMERA(agent, Hash40::new("d04final.nuanmb"), false);
+        }
+    }
+    else {
+        if macros::is_excute(agent) {
+            let scale = PostureModule::scale(agent.module_accessor);
+            macros::CAM_ZOOM_IN_arg5(agent, 3.0, 0.0, scale * 1.8, 0.0, 0.0);
+            macros::FT_START_CUTIN(agent);
+        }
+    }
+    frame(agent.lua_state_agent, 31.0);
+    if macros::is_excute(agent) {
+        macros::CAM_ZOOM_OUT(agent);
+    }
+    frame(agent.lua_state_agent, 60.0);
+    if macros::is_excute(agent) {
+        HitModule::set_whole(agent.module_accessor, HitStatus(*HIT_STATUS_NORMAL), 0);
+    }
+    frame(agent.lua_state_agent, 70.0);
+    if macros::is_excute(agent) {
+        ArticleModule::generate_article(agent.module_accessor, *FIGHTER_RYU_GENERATE_ARTICLE_SHINKUHADOKEN, false, -1);
+    }
+    frame(agent.lua_state_agent, 75.0);
+    if macros::is_excute(agent) {
+        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_REMOVE_FINAL_AURA);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("game_final", game_final, Priority::Low);
+
+    agent.acmd("game_finalair", game_final, Priority::Low);
+
+    agent.acmd("game_final2", game_final2, Priority::Low);
+
+    agent.acmd("game_finalair2", game_final2, Priority::Low);
+}

--- a/fighters/ryu/src/acmd/specials.rs
+++ b/fighters/ryu/src/acmd/specials.rs
@@ -350,9 +350,9 @@ unsafe extern "C" fn game_specialairs2(agent: &mut L2CAgentBase) {
     }
     macros::FT_MOTION_RATE(agent, 0.5);
     wait(agent.lua_state_agent, 1.0);
-    if macros::is_excute(agent) {
-        WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
-    }
+    // if macros::is_excute(agent) {
+    //     WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
+    // }
     if WorkModule::get_int(agent.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_S_INT_LOOP_COUNT) == 1 {
         if macros::is_excute(agent) {
             AttackModule::clear_all(agent.module_accessor);
@@ -367,6 +367,11 @@ unsafe extern "C" fn game_specialairs2(agent: &mut L2CAgentBase) {
         }
     }
     wait(agent.lua_state_agent, 3.0);
+    if WorkModule::get_int(agent.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_SPECIAL_S_INT_LOOP_COUNT) == 1 {
+        if macros::is_excute(agent) {
+            WorkModule::on_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
+        }
+    }
     if macros::is_excute(agent) {
         AttackModule::set_target_category(agent.module_accessor, 0, *COLLISION_CATEGORY_MASK_NO_IF as u32);
         AttackModule::set_size(agent.module_accessor, 0, 0.1);
@@ -431,6 +436,7 @@ unsafe extern "C" fn expression_specialairs2(agent: &mut L2CAgentBase) {
 
 unsafe extern "C" fn game_specialairs2end(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
+        WorkModule::off_flag(agent.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
         notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
         HitModule::set_status_all(agent.module_accessor, HitStatus(*HIT_STATUS_NORMAL), 0);
     }

--- a/fighters/ryu/src/agent_init.rs
+++ b/fighters/ryu/src/agent_init.rs
@@ -6,6 +6,29 @@ extern "C" {
 }
 
 pub unsafe extern "C" fn ryu_check_special_command(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let cat4 = fighter.global_table[CMD_CAT4].get_i32();
+    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_FINAL) {
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SUPER_SPECIAL_COMMAND != 0 {
+            fighter.clear_lua_stack();
+            lua_args!(fighter, Hash40::new_raw(0x229a8a3811));
+            sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+            if fighter.pop_lua_stack(1).get_bool() {
+                VarModule::on_flag(fighter.module_accessor, vars::ken::instance::flag::SKIP_FINAL_PROX_CHECK);
+                fighter.change_status(FIGHTER_RYU_STATUS_KIND_FINAL2.into(), true.into());
+                return true.into();
+            }
+        }
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SUPER_SPECIAL2_COMMAND != 0 {
+            fighter.clear_lua_stack();
+            lua_args!(fighter, Hash40::new_raw(0x229a8a3811));
+            sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+            if fighter.pop_lua_stack(1).get_bool() {
+                VarModule::on_flag(fighter.module_accessor, vars::ken::instance::flag::SKIP_FINAL_PROX_CHECK);
+                fighter.change_status(FIGHTER_STATUS_KIND_FINAL.into(), true.into());
+                return true.into();
+            }
+        }
+    }
     if VarModule::is_flag(fighter.module_accessor, vars::ryu::instance::flag::DENJIN_CHARGE)
     && !fighter.global_table[IS_STOP].get_bool()
     && fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
@@ -18,7 +41,6 @@ pub unsafe extern "C" fn ryu_check_special_command(fighter: &mut L2CFighterCommo
             return true.into();
         }
     }
-    let cat4 = fighter.global_table[CMD_CAT4].get_i32();
     if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_HI_COMMAND != 0
     && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI_COMMAND)
     && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[CHECK_SPECIAL_HI_UNIQ].clone()).get_bool() {

--- a/fighters/ryu/src/hadoken/acmd.rs
+++ b/fighters/ryu/src/hadoken/acmd.rs
@@ -10,7 +10,7 @@ unsafe extern "C" fn game_move(agent: &mut L2CAgentBase) {
 
 unsafe extern "C" fn game_movesp(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
-        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 2.0, 361, 10, 0, 42, 4.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 2, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_ENERGY);
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 6.0, 361, 10, 0, 42, 4.0, 0.0, 0.0, 0.0, None, None, None, 0.5, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 2, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_ENERGY);
         AttackModule::enable_safe_pos(agent.module_accessor);
     }
 }
@@ -21,7 +21,7 @@ unsafe extern "C" fn game_movesp_last(agent: &mut L2CAgentBase) {
     }
     frame(agent.lua_state_agent, 3.0);
     if macros::is_excute(agent) {
-        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 6.0, 361, 40, 0, 60, 5.0, 0.0, 0.0, -1.0, None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_ENERGY);
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 6.0, 100, 40, 0, 60, 5.0, 0.0, 0.0, -1.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_ENERGY);
         macros::ATK_SET_SHIELD_SETOFF_MUL(agent, 0, 2.2);
     }
 }

--- a/fighters/ryu/src/lib.rs
+++ b/fighters/ryu/src/lib.rs
@@ -21,6 +21,7 @@ mod agent_init;
 pub mod helper;
 
 mod hadoken;
+mod shinkuhadoken;
 
 pub fn install() {
     let agent = &mut Agent::new("ryu");
@@ -31,4 +32,5 @@ pub fn install() {
     agent.install();
 
     hadoken::install();
+    shinkuhadoken::install();
 }

--- a/fighters/ryu/src/shinkuhadoken/acmd.rs
+++ b/fighters/ryu/src/shinkuhadoken/acmd.rs
@@ -3,14 +3,14 @@ use super::*;
 unsafe extern "C" fn game_move(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 1.0);
     if macros::is_excute(agent) {
-        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 1.5, 25, 100, 60, 0, 8.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, false, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
-        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 1.5, 366, 100, 60, 0, 16.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, false, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 1.5, 25, 100, 60, 0, 8.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, true, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 1.5, 366, 100, 60, 0, 16.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, true, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
         // macros::ATTACK(agent, 2, 0, Hash40::new("top"), 0.0, 366, 100, 65, 0, 35.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, false, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
     }
     frame(agent.lua_state_agent, 75.0);
     if macros::is_excute(agent) {
         AttackModule::clear_all(agent.module_accessor);
-        macros::ATTACK(agent, 0, 1, Hash40::new("top"), 10.0, 50, 60, 0, 90, 18.0, 0.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+        macros::ATTACK(agent, 0, 1, Hash40::new("top"), 10.0, 50, 60, 0, 90, 18.0, 0.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
     }
     wait(agent.lua_state_agent, 6.0);
     if macros::is_excute(agent) {

--- a/fighters/ryu/src/shinkuhadoken/acmd.rs
+++ b/fighters/ryu/src/shinkuhadoken/acmd.rs
@@ -3,18 +3,9 @@ use super::*;
 unsafe extern "C" fn game_move(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 1.0);
     if macros::is_excute(agent) {
-        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 1.5, 25, 100, 60, 0, 8.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, true, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
-        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 1.5, 366, 100, 60, 0, 16.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, true, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 1.25, 25, 100, 60, 0, 8.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, true, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 1.25, 366, 100, 60, 0, 16.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, true, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
         // macros::ATTACK(agent, 2, 0, Hash40::new("top"), 0.0, 366, 100, 65, 0, 35.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, false, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
-    }
-    frame(agent.lua_state_agent, 75.0);
-    if macros::is_excute(agent) {
-        AttackModule::clear_all(agent.module_accessor);
-        macros::ATTACK(agent, 0, 1, Hash40::new("top"), 10.0, 50, 60, 0, 90, 18.0, 0.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
-    }
-    wait(agent.lua_state_agent, 6.0);
-    if macros::is_excute(agent) {
-        AttackModule::clear_all(agent.module_accessor);
     }
 }
 
@@ -24,7 +15,15 @@ unsafe extern "C" fn effect_move(agent: &mut L2CAgentBase) {
         macros::EFFECT_FOLLOW(agent, Hash40::new("ryu_final_shinkuhado_bullet"), Hash40::new("top"), 0, 0, 1, 0, 0, 0, 1.2, true);
         macros::EFFECT_FOLLOW(agent, Hash40::new("ryu_final_shinkuhado_bullet2"), Hash40::new("top"), 0, 0, 2, 0, 0, 0, 1.5, true);
     }
-    frame(agent.lua_state_agent, 75.0);
+}
+
+unsafe extern "C" fn game_finish(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        macros::ATTACK(agent, 0, 1, Hash40::new("top"), 10.0, 50, 60, 0, 90, 18.0, 0.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+    }
+}
+
+unsafe extern "C" fn effect_finish(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         macros::EFFECT(agent, Hash40::new("ryu_final_shinkuhado_finish"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
     }
@@ -33,4 +32,7 @@ unsafe extern "C" fn effect_move(agent: &mut L2CAgentBase) {
 pub fn install(agent: &mut Agent) {
     agent.acmd("game_move", game_move, Priority::Low);
     agent.acmd("effect_move", effect_move, Priority::Low);
+
+    agent.acmd("game_finish", game_finish, Priority::Low);
+    agent.acmd("effect_finish", effect_finish, Priority::Low);
 }

--- a/fighters/ryu/src/shinkuhadoken/acmd.rs
+++ b/fighters/ryu/src/shinkuhadoken/acmd.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+unsafe extern "C" fn game_move(agent: &mut L2CAgentBase) {
+    frame(agent.lua_state_agent, 1.0);
+    if macros::is_excute(agent) {
+        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 1.5, 25, 100, 60, 0, 8.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, false, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 1.5, 366, 100, 60, 0, 16.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, false, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+        // macros::ATTACK(agent, 2, 0, Hash40::new("top"), 0.0, 366, 100, 65, 0, 35.0, 0.0, 0.0, 0.0, None, None, None, 0.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 5, false, false, false, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+    }
+    frame(agent.lua_state_agent, 75.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+        macros::ATTACK(agent, 0, 1, Hash40::new("top"), 10.0, 50, 60, 0, 90, 18.0, 0.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+    }
+    wait(agent.lua_state_agent, 6.0);
+    if macros::is_excute(agent) {
+        AttackModule::clear_all(agent.module_accessor);
+    }
+}
+
+unsafe extern "C" fn effect_move(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        EffectModule::req_screen(agent.module_accessor, Hash40::new("bg_ryu_final_shinkuhado2"), false, false, false);
+        macros::EFFECT_FOLLOW(agent, Hash40::new("ryu_final_shinkuhado_bullet"), Hash40::new("top"), 0, 0, 1, 0, 0, 0, 1.2, true);
+        macros::EFFECT_FOLLOW(agent, Hash40::new("ryu_final_shinkuhado_bullet2"), Hash40::new("top"), 0, 0, 2, 0, 0, 0, 1.5, true);
+    }
+    frame(agent.lua_state_agent, 75.0);
+    if macros::is_excute(agent) {
+        macros::EFFECT(agent, Hash40::new("ryu_final_shinkuhado_finish"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("game_move", game_move, Priority::Low);
+    agent.acmd("effect_move", effect_move, Priority::Low);
+}

--- a/fighters/ryu/src/shinkuhadoken/mod.rs
+++ b/fighters/ryu/src/shinkuhadoken/mod.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+mod acmd;
+
+pub fn install() {
+    let agent = &mut Agent::new("ryu_shinkuhadoken");
+    acmd::install(agent);
+    agent.install();
+}

--- a/fighters/ryu/src/shinkuhadoken/mod.rs
+++ b/fighters/ryu/src/shinkuhadoken/mod.rs
@@ -1,9 +1,11 @@
 use super::*;
 
 mod acmd;
+mod status;
 
 pub fn install() {
     let agent = &mut Agent::new("ryu_shinkuhadoken");
     acmd::install(agent);
+    status::install(agent);
     agent.install();
 }

--- a/fighters/ryu/src/shinkuhadoken/status.rs
+++ b/fighters/ryu/src/shinkuhadoken/status.rs
@@ -1,0 +1,59 @@
+use super::*;
+
+unsafe extern "C" fn shinkuhadoken_move_main(weapon: &mut L2CWeaponCommon) -> L2CValue {
+    MotionModule::change_motion(
+        weapon.module_accessor,
+        Hash40::new("move"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+    weapon.fastshift(L2CValue::Ptr(shinkuhadoken_move_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn shinkuhadoken_move_main_loop(weapon: &mut L2CWeaponCommon) -> L2CValue {
+    if WorkModule::count_down_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LIFE, 0) {
+        weapon.change_status(vars::ryu_shinkuhadoken::status::FINISH.into(), false.into());
+    }
+    0.into()
+}
+
+unsafe extern "C" fn shinkuhadoken_finish_pre(weapon: &mut L2CWeaponCommon) -> L2CValue {
+    StatusModule::init_settings(
+        weapon.module_accessor,
+        SituationKind(*SITUATION_KIND_AIR),
+        *WEAPON_KINETIC_TYPE_NORMAL,
+        *GROUND_CORRECT_KIND_NONE as u32,
+        GroundCliffCheckKind(0),
+        false,
+        0,
+        0,
+        0,
+        0
+    );
+    0.into()
+}
+
+unsafe extern "C" fn shinkuhadoken_finish_main(weapon: &mut L2CWeaponCommon) -> L2CValue {
+    MotionAnimcmdModule::call_script_single(weapon.module_accessor, *WEAPON_ANIMCMD_GAME, Hash40::new("game_finish"), -1);
+    MotionAnimcmdModule::call_script_single(weapon.module_accessor, *WEAPON_ANIMCMD_EFFECT, Hash40::new("effect_finish"), -1);
+    weapon.fastshift(L2CValue::Ptr(shinkuhadoken_finish_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn shinkuhadoken_finish_main_loop(weapon: &mut L2CWeaponCommon) -> L2CValue {
+    if weapon.global_table[STATUS_FRAME].get_f32() >= 5.0 {
+        EffectModule::detach_all(weapon.module_accessor, 5);
+        notify_event_msc_cmd!(weapon, Hash40::new_raw(0x199c462b5d));
+    }
+    0.into()
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *WEAPON_RYU_SHINKUHADOKEN_STATUS_KIND_MOVE, shinkuhadoken_move_main);
+
+    agent.status(Pre, vars::ryu_shinkuhadoken::status::FINISH, shinkuhadoken_finish_pre);
+    agent.status(Main, vars::ryu_shinkuhadoken::status::FINISH, shinkuhadoken_finish_main);
+}

--- a/fighters/ryu/src/status.rs
+++ b/fighters/ryu/src/status.rs
@@ -37,6 +37,8 @@ mod special_lw_step_f;
 // Reused for Denjin Impact / Denjin Reversal
 mod special_lw_step_b;
 
+mod r#final;
+
 pub fn install(agent: &mut Agent) {
     rebirth::install(agent);
 
@@ -72,4 +74,6 @@ pub fn install(agent: &mut Agent) {
     special_lw_step_f::install(agent);
 
     special_lw_step_b::install(agent);
+
+    r#final::install(agent);
 }

--- a/fighters/ryu/src/status/final/final1.rs
+++ b/fighters/ryu/src/status/final/final1.rs
@@ -1,0 +1,82 @@
+use super::*;
+
+unsafe extern "C" fn ryu_final_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if !VarModule::is_flag(fighter.module_accessor, vars::ryu::instance::flag::SKIP_FINAL_PROX_CHECK) {
+        fighter.sub_status_pre_FinalCommon();
+        fighter.clear_lua_stack();
+        lua_args!(fighter, Hash40::new_raw(0x20e3e3c94b));
+        sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+        if !fighter.pop_lua_stack(1).get_bool() {
+            StatusModule::set_status_kind_interrupt(fighter.module_accessor, *FIGHTER_RYU_STATUS_KIND_FINAL2);
+            return 1.into();
+        }
+    }
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_NONE),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_NONE as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
+        false,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_DISABLE,
+        false,
+        false,
+        false,
+        (
+            *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_FINAL|
+            *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK |
+            *FIGHTER_LOG_MASK_FLAG_ACTION_TRIGGER_ON
+        ) as u64,
+        (
+            *FIGHTER_STATUS_ATTR_DISABLE_ITEM_INTERRUPT |
+            *FIGHTER_STATUS_ATTR_DISABLE_TURN_DAMAGE |
+            *FIGHTER_STATUS_ATTR_FINAL
+        ) as u32,
+        *FIGHTER_POWER_UP_ATTACK_BIT_FINAL as u32,
+        0
+    );
+    0.into()
+}
+
+unsafe extern "C" fn ryu_final_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    VarModule::off_flag(fighter.module_accessor, vars::ryu::instance::flag::SKIP_FINAL_PROX_CHECK);
+
+    notify_event_msc_cmd!(fighter, Hash40::new_raw(0x201bc9217c));
+
+    // HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    let mot = if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        "final"
+    }
+    else {
+        "final_air"
+    };
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new(mot),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    ItemModule::set_change_status_event(fighter.module_accessor, false);
+
+    let main_loop = smashline::api::get_target_function("lua2cpp_ryu.nrs", 0x43f70).unwrap();
+    fighter.sub_shift_status_main(L2CValue::Ptr(main_loop as *const () as _))
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Pre, *FIGHTER_STATUS_KIND_FINAL, ryu_final_pre);
+    agent.status(Main, *FIGHTER_STATUS_KIND_FINAL, ryu_final_main);
+}

--- a/fighters/ryu/src/status/final/final1_air_end.rs
+++ b/fighters/ryu/src/status/final/final1_air_end.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+unsafe extern "C" fn ryu_final_air_end_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    let mot = if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_HIT) {
+        "final_hit_air_end"
+    }
+    else {
+        "final_air_end"
+    };
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new(mot),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    let main_loop = smashline::api::get_target_function("lua2cpp_ryu.nrs", 0x435d0).unwrap();
+    fighter.sub_shift_status_main(L2CValue::Ptr(main_loop as *const () as _))
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_RYU_STATUS_KIND_FINAL_AIR_END, ryu_final_air_end_main);
+}

--- a/fighters/ryu/src/status/final/final1_fall.rs
+++ b/fighters/ryu/src/status/final/final1_fall.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+unsafe extern "C" fn ryu_final_fall_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    let mot = if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_HIT) {
+        "final_hit_fall"
+    }
+    else {
+        "final_fall"
+    };
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new(mot),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(ryu_final_fall_substatus as *const () as _));
+
+    let main_loop = smashline::api::get_target_function("lua2cpp_ryu.nrs", 0x43b30).unwrap();
+    fighter.sub_shift_status_main(L2CValue::Ptr(main_loop as *const () as _))
+}
+
+unsafe extern "C" fn ryu_final_fall_substatus(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
+    if param_1.get_bool() {
+        WorkModule::dec_int(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_INT_COUNTER);
+    }
+    0.into()
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_RYU_STATUS_KIND_FINAL_FALL, ryu_final_fall_main);
+}

--- a/fighters/ryu/src/status/final/final1_hit.rs
+++ b/fighters/ryu/src/status/final/final1_hit.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+unsafe extern "C" fn ryu_final_hit_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    let mut zoom = 1.1;
+    if PostureModule::scale(fighter.module_accessor) > 1.0 {
+        zoom *= PostureModule::scale(fighter.module_accessor);
+    }
+    CameraModule::zoom_in(
+        fighter.module_accessor,
+        5,
+        0,
+        zoom,
+        &Vector2f{x: 0.0, y: 0.0},
+        true
+    );
+
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_NO_DEAD);
+
+    let mot = if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        "final_hit"
+    }
+    else {
+        "final_air_hit"
+    };
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new(mot),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    let main_loop = smashline::api::get_target_function("lua2cpp_ryu.nrs", 0x430a0).unwrap();
+    fighter.sub_shift_status_main(L2CValue::Ptr(main_loop as *const () as _))
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_RYU_STATUS_KIND_FINAL_HIT, ryu_final_hit_main);
+}

--- a/fighters/ryu/src/status/final/final1_jump.rs
+++ b/fighters/ryu/src/status/final/final1_jump.rs
@@ -1,0 +1,12 @@
+use super::*;
+
+unsafe extern "C" fn ryu_final_jump_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    let main_loop = smashline::api::get_target_function("lua2cpp_ryu.nrs", 0x43e90).unwrap();
+    fighter.sub_shift_status_main(L2CValue::Ptr(main_loop as *const () as _))
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_RYU_STATUS_KIND_FINAL_JUMP, ryu_final_jump_main);
+}

--- a/fighters/ryu/src/status/final/final1_landing.rs
+++ b/fighters/ryu/src/status/final/final1_landing.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+unsafe extern "C" fn ryu_final_landing_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    let mot = if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_RYU_STATUS_WORK_ID_FINAL_FLAG_HIT) {
+        "final_hit_landing"
+    }
+    else {
+        "final_landing"
+    };
+    let end_frame = MotionModule::end_frame_from_hash(fighter.module_accessor, Hash40::new(mot));
+    let final2_landing_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("param_private"), hash40("final_landing_frame")) as f32;
+    let rate = end_frame / final2_landing_frame;
+
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new(mot),
+        0.0,
+        rate,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    let main_loop = smashline::api::get_target_function("lua2cpp_ryu.nrs", 0x43770).unwrap();
+    fighter.sub_shift_status_main(L2CValue::Ptr(main_loop as *const () as _))
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_RYU_STATUS_KIND_FINAL_LANDING, ryu_final_landing_main);
+}

--- a/fighters/ryu/src/status/final/mod.rs
+++ b/fighters/ryu/src/status/final/mod.rs
@@ -1,0 +1,17 @@
+use super::*;
+
+mod final1;
+mod final1_jump;
+mod final1_hit;
+mod final1_fall;
+mod final1_landing;
+mod final1_air_end;
+
+pub fn install(agent: &mut Agent) {
+    final1::install(agent);
+    final1_jump::install(agent);
+    final1_hit::install(agent);
+    final1_fall::install(agent);
+    final1_landing::install(agent);
+    final1_air_end::install(agent);
+}

--- a/fighters/ryu/src/status/special_n2.rs
+++ b/fighters/ryu/src/status/special_n2.rs
@@ -160,13 +160,7 @@ unsafe extern "C" fn ryu_special_n2_main_loop(fighter: &mut L2CFighterCommon) ->
             return 1.into();
         }
     }
-    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL)
-    && AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_SHIELD | *COLLISION_KIND_MASK_HIT) {
-        let sitation = fighter.global_table[SITUATION_KIND].get_i32();
-        if ryu_final_hit_cancel(fighter, sitation.into()).get_bool() {
-            return 1.into();
-        }
-    }
+
     if StatusModule::is_changing(fighter.module_accessor)
     || StatusModule::is_situation_changed(fighter.module_accessor) {
         if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_GROUND {

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -2,7 +2,7 @@ pub use {
     smash::{
         hash40,
         phx::*,
-        app::{lua_bind::*, *},
+        app::{self, lua_bind::*, *},
         lib::{lua_const::*, L2CValue, L2CAgent}
     },
     smash_script::*,

--- a/src/system/engine.rs
+++ b/src/system/engine.rs
@@ -39,6 +39,9 @@ pub fn install() {
     skyline::patching::Patch::in_text(0x617a90).nop();
     skyline::patching::Patch::in_text(0x617aa4).nop();
 
+    // Removes the forced change to HIT_STATUS_OFF during Final Smash
+    skyline::patching::Patch::in_text(0x62d5ac).nop();
+
     skyline::install_hooks!(
         change_elec_hitlag_for_attacker,
         autoturn_handler,

--- a/src/vtable_hook.rs
+++ b/src/vtable_hook.rs
@@ -22,6 +22,7 @@ mod wario;
 mod weapon;
 mod mariod_drcapsule;
 mod belmont_cross;
+mod ryu_shinkuhadoken;
 
 pub fn install() {
     fighter::install();
@@ -48,4 +49,5 @@ pub fn install() {
     weapon::install();
     mariod_drcapsule::install();
     belmont_cross::install();
+    ryu_shinkuhadoken::install();
 }

--- a/src/vtable_hook/ryu_shinkuhadoken.rs
+++ b/src/vtable_hook/ryu_shinkuhadoken.rs
@@ -1,0 +1,13 @@
+use crate::imports::*;
+
+unsafe extern "C" fn shinku_on_hit(vtable: u64, weapon: *mut app::Weapon, something: u32) -> u64 {
+    *(weapon as *mut bool).add(0x90) = true;
+    normal_weapon_hit_handler(vtable, weapon, something)
+}
+
+#[skyline::from_offset(0x33bdc10)]
+unsafe extern "C" fn normal_weapon_hit_handler(vtable: u64, weapon: *mut app::Weapon, something: u32) -> u64;
+
+pub fn install() {
+    let _ = skyline::patching::Patch::in_text(0x5215940).data(shinku_on_hit as u64);
+}

--- a/src/vtable_hook/shotos.rs
+++ b/src/vtable_hook/shotos.rs
@@ -401,7 +401,58 @@ unsafe extern "C" fn ryu_ken_on_damage(vtable: u64, fighter: &mut Fighter, on_da
     }
 }
 
+#[skyline::hook(offset = 0x10d5f30)]
+unsafe extern "C" fn ryu_ken_frame(vtable: u64, fighter: &mut Fighter) {
+    original!()(vtable, fighter);
+    let object = &mut fighter.battle_object;
+    let module_accessor = (*object).module_accessor;
+
+    let battle_object_slow = singletons::BattleObjectSlow() as *mut u8;
+    if *battle_object_slow.add(0x8) != 0 && *(battle_object_slow as *const u32) != 2 {
+        return;
+    }
+
+    if WorkModule::is_flag(module_accessor, 0x200000e9)
+    && WorkModule::is_flag(module_accessor, *FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL) {
+        let work_module = *(module_accessor as *const *const u64).add(0x50 / 8);
+        if ryu_ken_check_final_can_cancel(work_module) {
+            let cat1 = ControlModule::get_command_flag_cat(module_accessor, 0);
+            let cat4 = ControlModule::get_command_flag_cat(module_accessor, 3);
+            let mut status = -1;
+            if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SUPER_SPECIAL_COMMAND != 0 {
+                VarModule::on_flag(module_accessor, ryu::instance::flag::SKIP_FINAL_PROX_CHECK);
+                status = *FIGHTER_RYU_STATUS_KIND_FINAL2;
+            }
+            else if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SUPER_SPECIAL2_COMMAND != 0 {
+                VarModule::on_flag(module_accessor, ryu::instance::flag::SKIP_FINAL_PROX_CHECK);
+                status = *FIGHTER_STATUS_KIND_FINAL;
+            }
+            else if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_N != 0 {
+                status = *FIGHTER_STATUS_KIND_FINAL;
+            }
+            if status != -1 {
+                if StopModule::is_stop(module_accessor) && StopModule::is_hit(module_accessor) {
+                    StopModule::cancel_hit_stop(module_accessor);
+                }
+                if SlowModule::frame(module_accessor, 1) > 1 {
+                    SlowModule::clear_immediate(module_accessor, 1, false);
+                }
+                StatusModule::change_status_request(module_accessor, status, true);
+            }
+        }
+    }
+}
+
+#[skyline::from_offset(0x695c80)]
+fn ryu_ken_check_final_can_cancel(work_module: *const u64) -> bool;
+
 pub fn install() {
+    // Patches the original final smash cancel check
+    let _ = skyline::patching::Patch::in_text(0x10d6324).data(0x14000039u32);
+
+    // Allows any status over 0x1de to be final smash cancelable
+    let _ = skyline::patching::Patch::in_text(0x10d67d8).data(0x1400000Au32);
+
     skyline::install_hooks!(
         ryu_ken_init,
         ryu_ken_move_strength_autoturn_handler,
@@ -410,6 +461,7 @@ pub fn install() {
         ryu_ken_on_hit,
         ryu_ken_on_hit_2,
         ryu_ken_on_search,
-        ryu_ken_on_damage
+        ryu_ken_on_damage,
+        ryu_ken_frame
     );
 }

--- a/src/vtable_hook/shotos.rs
+++ b/src/vtable_hook/shotos.rs
@@ -312,6 +312,11 @@ unsafe extern "C" fn ryu_ken_on_hit(vtable: u64, fighter: &mut Fighter, log: u64
         }
         return;
     }
+    if status == *FIGHTER_STATUS_KIND_FINAL {
+        if collision_kind != 1 {
+            return;
+        }
+    }
     original!()(vtable, fighter, log, some_float);
 }
 

--- a/src/vtable_hook/shotos.rs
+++ b/src/vtable_hook/shotos.rs
@@ -18,6 +18,9 @@ unsafe extern "C" fn ryu_ken_init(_vtable: u64, fighter: &mut Fighter) {
         FGCModule::clone_command_input(module_accessor, Cat4::SPECIAL_N_COMMAND, Cat4::ATTACK_COMMAND1);
         FGCModule::set_command_input_button(module_accessor, Cat4::ATTACK_COMMAND1, 2);
     }
+    FGCModule::clone_command_input(module_accessor, Cat4::SUPER_SPECIAL2_COMMAND, Cat4::SUPER_SPECIAL_COMMAND);
+    FGCModule::set_command_input_button(module_accessor, Cat4::SUPER_SPECIAL_COMMAND, 1);
+    FGCModule::set_command_input_button(module_accessor, Cat4::SUPER_SPECIAL2_COMMAND, 2);
 }
 
 #[skyline::from_offset(0x646fe0)]


### PR DESCRIPTION
The beginning of an effort to make final smash meter viable. Will take a very long time to complete.

General goals are:
- Remove the massive amount of intangibility Final Smashes have after their active frames are finished.
- Ensure that non-command grab Final Smashes can be blocked.
- Redesign problematic Final Smashes.

# Changelog

## Ryu

### Hadoken
Increased the damage of Denjin Hadoken (2+6 > 6+6).
Adjusted the angle of Denjin Hadoken (361 > 100).

### Hashogeki

Can now be canceled into Final Smash.

### Shinku Hadoken
Can now be performed with 236236A.
Superflash slowdown adjusted so the projectile is fired on what is effectively frame 11.
Ryu is now only intangibile during the superflash.

Reduced total projectile lifetime (95 > 80).
Reduced travel speed (1.3 > 1.1).
Removed the massive windbox pulling you into the move. Adjusted the other hitboxes to compensate.
Damage of the multihits adjusted to compensate for the reduced travel time (1.0 > 1.25).
Can now be blocked and reflected.

### Shin Shoryuken
Can now be performed with 236236B.
Intangibility adjusted to disappear after the initial hit if it whiffs.
Superflash adjusted so that this is now effectively a frame 1 super.
Removed the locking, paralyzing hitbox during the superflash.
Can now be blocked.

## Ken

The Simple Input Final Smashes were swapped - Shippu Jinraikyaku is now the "far" Final Smash, with Shinryuken being the close final smash.

### Quick Dash

Can now be canceled into Final Smash.

### Jinrai Kicks

Can now be canceled into Final Smash.

### Dragonlash Kick

Can now be canceled into Final Smash.

### Shinryuken
Will hopefully turn into Shinryureppa soon.
Can now be performed with 236236A.
Removed initial pull-in hitboxes.
Intangibility adjusted to last until until the launcher hitbox ends.
Can now be blocked.

### Shippu Jinraikyaku
Can now be performed with 236236B.
Removed the locking, paralyzing hitbox during the superflash.
Ingantibility adjusted to disappear after the first kick hitbox, even if the full move connects.
Can now be blocked.