### PR TITLE
Small Recovery Reversions

### DIFF
--- a/fighters/brave/src/acmd/specials.rs
+++ b/fighters/brave/src/acmd/specials.rs
@@ -35,7 +35,7 @@ unsafe extern "C" fn game_specialhi2(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 40.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_BRAVE_STATUS_SPECIAL_HI_FLAG_REVERT_ANGLE);
-        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
     }
 }
 

--- a/fighters/brave/src/acmd/specials.rs
+++ b/fighters/brave/src/acmd/specials.rs
@@ -28,13 +28,14 @@ unsafe extern "C" fn game_specialhi2(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_BRAVE_STATUS_SPECIAL_HI_FLAG_JUMP_START);
     }
-    frame(agent.lua_state_agent, 20.0);
-    if macros::is_excute(agent) {
-        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
-    }
+    // frame(agent.lua_state_agent, 20.0);
+    // if macros::is_excute(agent) {
+    //     notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
+    // }
     frame(agent.lua_state_agent, 40.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_BRAVE_STATUS_SPECIAL_HI_FLAG_REVERT_ANGLE);
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
     }
 }
 
@@ -47,13 +48,17 @@ unsafe extern "C" fn game_specialhi3(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_BRAVE_STATUS_SPECIAL_HI_FLAG_JUMP_START);
     }
-    frame(agent.lua_state_agent, 18.0);
-    if macros::is_excute(agent) {
-        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
-    }
+    // frame(agent.lua_state_agent, 18.0);
+    // if macros::is_excute(agent) {
+    //     notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
+    // }
     frame(agent.lua_state_agent, 30.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_BRAVE_STATUS_SPECIAL_HI_FLAG_REVERT_ANGLE);
+    }
+    frame(agent.lua_state_agent, 50.0);
+    if macros::is_excute(agent) {
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
     }
 }
 

--- a/fighters/buddy/src/acmd/specials.rs
+++ b/fighters/buddy/src/acmd/specials.rs
@@ -9,10 +9,10 @@ unsafe extern "C" fn game_specialhi(agent: &mut L2CAgentBase) {
             false
         );
     }
-    frame(agent.lua_state_agent, 9.0);
-    if macros::is_excute(agent) {
-        // notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
-    }
+    // frame(agent.lua_state_agent, 9.0);
+    // if macros::is_excute(agent) {
+    //     notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
+    // }
     frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_BUDDY_STATUS_SPECIAL_HI_FLAG_RESET_CONTROL);

--- a/fighters/dedede/src/acmd/specials.rs
+++ b/fighters/dedede/src/acmd/specials.rs
@@ -8,7 +8,7 @@ unsafe extern "C" fn game_specialhijump(agent: &mut L2CAgentBase) {
     }
     frame(agent.lua_state_agent, 5.0);
     if macros::is_excute(agent) {
-        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
     }
     frame(agent.lua_state_agent, 11.0);
     if macros::is_excute(agent) {

--- a/fighters/duckhunt/src/acmd/specials.rs
+++ b/fighters/duckhunt/src/acmd/specials.rs
@@ -4,6 +4,7 @@ unsafe extern "C" fn game_specialhi(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 39.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_DUCKHUNT_INSTANCE_WORK_ID_FLAG_REQUEST_SPECIAL_HI_CANCEL);
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
     }
 }
 

--- a/fighters/inkling/src/acmd.rs
+++ b/fighters/inkling/src/acmd.rs
@@ -4,6 +4,8 @@ mod dash;
 
 mod normals;
 mod aerials;
+mod specials;
+
 mod catch;
 
 mod escape;
@@ -14,6 +16,9 @@ pub fn install(agent: &mut Agent) {
 
     normals::install(agent);
     aerials::install(agent);
+
+    specials::install(agent);
+
     catch::install(agent);
 
     escape::install(agent);

--- a/fighters/inkling/src/acmd/specials.rs
+++ b/fighters/inkling/src/acmd/specials.rs
@@ -1,0 +1,12 @@
+use super::*;
+
+unsafe extern "C" fn game_specialhijump(agent: &mut L2CAgentBase) {
+    frame(agent.lua_state_agent, 20.0);
+    if macros::is_excute(agent) {
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("game_specialhijump", game_specialhijump, Priority::Low);
+}

--- a/fighters/koopajr/src/acmd/specials.rs
+++ b/fighters/koopajr/src/acmd/specials.rs
@@ -5,9 +5,9 @@ unsafe extern "C" fn game_specialhijrrise(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_KOOPAJR_STATUS_SPECIAL_HI_SHOOT_FLAG_ACTION);
     }
-    frame(agent.lua_state_agent, 13.0);
+    frame(agent.lua_state_agent, 25.0);
     if macros::is_excute(agent) {
-        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
     }
 }
 

--- a/fighters/murabito/src/status.rs
+++ b/fighters/murabito/src/status.rs
@@ -2,14 +2,14 @@ use super::*;
 
 mod special_n_search;
 
-mod special_hi_wait;
-mod special_hi_flap;
-mod special_hi_turn;
+// mod special_hi_wait;
+// mod special_hi_flap;
+// mod special_hi_turn;
 
 pub fn install(agent: &mut Agent) {
     special_n_search::install(agent);
 
-    special_hi_wait::install(agent);
-    special_hi_flap::install(agent);
-    special_hi_turn::install(agent);
+    // special_hi_wait::install(agent);
+    // special_hi_flap::install(agent);
+    // special_hi_turn::install(agent);
 }

--- a/fighters/packun/src/acmd/specials.rs
+++ b/fighters/packun/src/acmd/specials.rs
@@ -24,6 +24,10 @@ unsafe extern "C" fn game_specialhi(agent: &mut L2CAgentBase) {
         macros::ATTACK(agent, 3, 0, Hash40::new("arml"), 1.2, 367, 100, 0, 20, 5.0, 1.5, 0.0, 0.0, None, None, None, 0.6, 3.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 6, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_PUNCH);
         macros::ATTACK(agent, 4, 0, Hash40::new("armr"), 1.2, 367, 100, 0, 20, 5.0, 1.5, 0.0, 0.0, None, None, None, 0.6, 3.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 6, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_PUNCH);
     }
+    frame(agent.lua_state_agent, 30.0);
+    if macros::is_excute(agent) {
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
+    }
     frame(agent.lua_state_agent, 58.0);
     if macros::is_excute(agent) {
         macros::ATTACK(agent, 1, 0, Hash40::new("arml"), 4.0, 60, 60, 0, 90, 3.0, 8.0, 0.0, 0.0, None, None, None, 0.6, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 6, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_PUNCH);

--- a/fighters/pit/src/acmd/specials.rs
+++ b/fighters/pit/src/acmd/specials.rs
@@ -41,14 +41,12 @@ unsafe extern "C" fn game_specialhi(agent: &mut L2CAgentBase) {
         JostleModule::set_status(agent.module_accessor, false);
     }
     frame(agent.lua_state_agent, 10.0);
-    if macros::is_excute(agent) {
-        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES); // Vanilla
-    }
     macros::FT_MOTION_RATE(agent, 8.0/34.0);
     frame(agent.lua_state_agent, 44.0);
     macros::FT_MOTION_RATE(agent, 1.0);
     frame(agent.lua_state_agent, 45.0);
     if macros::is_excute(agent) {
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_PIT_STATUS_SPECIAL_HI_RUSH_FLAG_FIX_ANGLE);
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_PIT_STATUS_SPECIAL_HI_RUSH_FLAG_BACK_ANGLE);
         JostleModule::set_status(agent.module_accessor, true);

--- a/fighters/reflet/src/acmd/specials.rs
+++ b/fighters/reflet/src/acmd/specials.rs
@@ -12,7 +12,7 @@ unsafe extern "C" fn game_specialhi(agent: &mut L2CAgentBase) {
     }
     frame(agent.lua_state_agent, 28.0);
     if macros::is_excute(agent) {
-        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES); // Was ALWAYS_BOTH_SIDES
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
     }
     frame(agent.lua_state_agent, 40.0);
     if macros::is_excute(agent) {
@@ -29,7 +29,7 @@ unsafe extern "C" fn game_specialhi2(agent: &mut L2CAgentBase) {
     }
     frame(agent.lua_state_agent, 27.0);
     if macros::is_excute(agent) {
-        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES); // Was ALWAYS_BOTH_SIDES
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
     }
 }
 

--- a/fighters/rosetta/src/acmd/specials.rs
+++ b/fighters/rosetta/src/acmd/specials.rs
@@ -4,21 +4,12 @@ unsafe extern "C" fn game_specialhi(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         JostleModule::set_status(agent.module_accessor, false);
     }
-    frame(agent.lua_state_agent, 12.0);
+    frame(agent.lua_state_agent, 24.0);
     if macros::is_excute(agent) {
-        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP); // Was ALWAYS
-    }
-}
-
-unsafe extern "C" fn game_specialhiend(agent: &mut L2CAgentBase) {
-    if macros::is_excute(agent) {
-        JostleModule::set_status(agent.module_accessor, false);
-        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES); // Was ALWAYS_BOTH_SIDES
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
     }
 }
 
 pub fn install(agent: &mut Agent) {
     agent.acmd("game_specialhi", game_specialhi, Priority::Low);
-
-    agent.acmd("game_specialhiend", game_specialhiend, Priority::Low);
 }

--- a/fighters/shizue/src/status.rs
+++ b/fighters/shizue/src/status.rs
@@ -2,18 +2,18 @@ use super::*;
 
 mod special_n_search;
 
-mod special_hi_wait;
-mod special_hi_flap;
-mod special_hi_turn;
+// mod special_hi_wait;
+// mod special_hi_flap;
+// mod special_hi_turn;
 
 mod special_lw_fire;
 
 pub fn install(agent: &mut Agent) {
     special_n_search::install(agent);
     
-    special_hi_wait::install(agent);
-    special_hi_flap::install(agent);
-    special_hi_turn::install(agent);
+    // special_hi_wait::install(agent);
+    // special_hi_flap::install(agent);
+    // special_hi_turn::install(agent);
 
     special_lw_fire::install(agent);
 }

--- a/fighters/snake/src/acmd/specials.rs
+++ b/fighters/snake/src/acmd/specials.rs
@@ -27,9 +27,9 @@ unsafe extern "C" fn game_specialairhihang(agent: &mut L2CAgentBase) {
     WorkModule::unable_transition_term_group_ex(agent.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_AERIAL);
     WorkModule::unable_transition_term_group_ex(agent.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_AERIAL_BUTTON);
     WorkModule::unable_transition_term_group_ex(agent.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI);
-    // if macros::is_excute(agent) {
-    //     notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
-    // }
+    if macros::is_excute(agent) {
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
+    }
     frame(agent.lua_state_agent, 74.0);
     if macros::is_excute(agent) {
         WorkModule::enable_transition_term(agent.module_accessor, *FIGHTER_SNAKE_STATUS_CYPHER_HANG_TRANS_ID_CUT_TIME_OUT);

--- a/fighters/yoshi/src/acmd/specials.rs
+++ b/fighters/yoshi/src/acmd/specials.rs
@@ -100,6 +100,7 @@ unsafe extern "C" fn game_specialairhi(agent: &mut L2CAgentBase) {
     frame(agent.lua_state_agent, 30.0);
     if macros::is_excute(agent) {
         VarModule::on_flag(agent.module_accessor, vars::yoshi::status::flag::SPECIAL_HI_RISE_CUT);
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
     }
 }
 


### PR DESCRIPTION
In 0.17.0, recoveries were made universally like Melee, where you could only snap to the ledge while going downwards. In 0.17.1, some more linear recoveries had this change reverted due to the late addition of reverse Ledge Trump. Here, we're bringing more characters in-line with the changes made in 0.17.1:
- Characters with linear recoveries
- Characters with no hitbox on their recoveries

# Changelog:
## Hero

- Woosh: Unchanged
- Swoosh: Can now snap to ledge on frame 40 while going up.
- Kaswoosh: Can now snap to ledge on frame 50 while going up.

## King Dedede

- Super Dedede Jump: Can now snap to ledge on frame 5 while going upwards on both sides.

## Duck Hunt

- Duck Jump: Can now snap to ledge on frame 39 during the move's free movement (the same frame you can cancel the move).

## Inkling

- Super Jump: Can now snap to ledge on frame 20 after jumping.

## Bowser Jr.

- Abandon Ship!: Can now snap to ledge on frame 25 after jumping.

## Piranha Plant

- Piranhacopter: Can now snap to ledge on frame 30 after he begins to rise.

## Pit

- Power of Flight: Can now snap to ledge uuuuuuuh near the end of the move idk the framedata sorry.

## Robin

- Elwind: On the second Elwind, Robin can now snap to ledge on frame 27.

## Rosalina & Luma

- Launch Star: Can now snap to ledge on frame 24 after being launched.

## Villager & Isabelle

- Balloon Trip: Can now snap to ledge all the time.

##  Yoshi

- Flutter Jump: Can now snap to ledge on frame 30 while rising.