### PR TITLE
Landing Shake Removal

### DIFF
--- a/fighters/dedede/src/acmd.rs
+++ b/fighters/dedede/src/acmd.rs
@@ -2,6 +2,8 @@ use super::*;
 
 mod dash;
 
+mod landing;
+
 mod normals;
 mod smashes;
 mod aerials;
@@ -14,6 +16,8 @@ mod cliff;
 
 pub fn install(agent: &mut Agent) {
     dash::install(agent);
+
+    landing::install(agent);
 
     normals::install(agent);
     smashes::install(agent);

--- a/fighters/dedede/src/acmd/aerials.rs
+++ b/fighters/dedede/src/acmd/aerials.rs
@@ -65,10 +65,72 @@ unsafe extern "C" fn game_attackairlw(agent: &mut L2CAgentBase) {
     }
 }
 
+unsafe extern "C" fn expression_landingairn(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 4);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_M);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_lands_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 15.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 7);
+    }
+}
+
+unsafe extern "C" fn expression_landingairf(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_M);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_TOP);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_lands_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 10.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 10);
+    }
+}
+
+unsafe extern "C" fn expression_landingairb(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_M);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_TOP);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_lands_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 20.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 8);
+    }
+}
+
+unsafe extern "C" fn expression_landingairhi(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_M);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_lands_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+}
+
+unsafe extern "C" fn expression_landingairlw(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_M);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_lands_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+}
+
 pub fn install(agent: &mut Agent) {
     agent.acmd("game_attackairf", game_attackairf, Priority::Low);
 
     agent.acmd("game_attackairb", game_attackairb, Priority::Low);
 
     agent.acmd("game_attackairlw", game_attackairlw, Priority::Low);
+
+    agent.acmd("expression_landingairn", expression_landingairn, Priority::Low);
+
+    agent.acmd("expression_landingairf", expression_landingairf, Priority::Low);
+
+    agent.acmd("expression_landingairb", expression_landingairb, Priority::Low);
+
+    agent.acmd("expression_landingairhi", expression_landingairhi, Priority::Low);
+
+    agent.acmd("expression_landingairlw", expression_landingairlw, Priority::Low);
 }

--- a/fighters/dedede/src/acmd/landing.rs
+++ b/fighters/dedede/src/acmd/landing.rs
@@ -1,0 +1,14 @@
+use super::*;
+
+unsafe extern "C" fn expression_landingheavy(agent: &mut L2CAgentBase) {
+    let expression_common : &mut smash::lua2cpp::L2CFighterAnimcmdExpressionCommon = std::mem::transmute(&mut *agent);
+    expression_common.expression_LandingHeavyRumble();
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("expression_landingheavy", expression_landingheavy, Priority::Low);
+}

--- a/fighters/donkey/src/acmd.rs
+++ b/fighters/donkey/src/acmd.rs
@@ -2,6 +2,8 @@ use super::*;
 
 mod dash;
 
+mod landing;
+
 mod normals;
 mod aerials;
 mod specials;
@@ -13,6 +15,8 @@ mod cliff;
 
 pub fn install(agent: &mut Agent) {
     dash::install(agent);
+
+    landing::install(agent);
 
     normals::install(agent);
     aerials::install(agent);

--- a/fighters/donkey/src/acmd/landing.rs
+++ b/fighters/donkey/src/acmd/landing.rs
@@ -1,0 +1,14 @@
+use super::*;
+
+unsafe extern "C" fn expression_landingheavy(agent: &mut L2CAgentBase) {
+    let expression_common : &mut smash::lua2cpp::L2CFighterAnimcmdExpressionCommon = std::mem::transmute(&mut *agent);
+    expression_common.expression_LandingHeavyRumble();
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("expression_landingheavy", expression_landingheavy, Priority::Low);
+}

--- a/fighters/koopa/src/acmd.rs
+++ b/fighters/koopa/src/acmd.rs
@@ -2,6 +2,8 @@ use super::*;
 
 mod dash;
 
+mod landing;
+
 mod normals;
 mod aerials;
 mod specials;
@@ -15,6 +17,8 @@ mod appeal;
 
 pub fn install(agent: &mut Agent) {
     dash::install(agent);
+
+    landing::install(agent);
 
     normals::install(agent);
     aerials::install(agent);

--- a/fighters/koopa/src/acmd/aerials.rs
+++ b/fighters/koopa/src/acmd/aerials.rs
@@ -22,6 +22,58 @@ unsafe extern "C" fn game_attackairn(agent: &mut L2CAgentBase) {
     }
 }
 
+unsafe extern "C" fn expression_landingairn(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 6);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_landl_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 19.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 8);
+    }
+}
+
+unsafe extern "C" fn expression_landingairf(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 4);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_landl_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 19.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 6);
+    }
+}
+
+unsafe extern "C" fn expression_landingairb(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 3);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_landl_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 23.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 6);
+    }
+}
+
+unsafe extern "C" fn expression_landingairhi(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_landl_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+}
+
 pub fn install(agent: &mut Agent) {
     agent.acmd("game_attackairn", game_attackairn, Priority::Low);
+
+    agent.acmd("expression_landingairn", expression_landingairn, Priority::Low);
+
+    agent.acmd("expression_landingairf", expression_landingairf, Priority::Low);
+
+    agent.acmd("expression_landingairb", expression_landingairb, Priority::Low);
+
+    agent.acmd("expression_landingairhi", expression_landingairhi, Priority::Low);
 }

--- a/fighters/koopa/src/acmd/landing.rs
+++ b/fighters/koopa/src/acmd/landing.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+unsafe extern "C" fn expression_landinglight(agent: &mut L2CAgentBase) {
+    let expression_common : &mut smash::lua2cpp::L2CFighterAnimcmdExpressionCommon = std::mem::transmute(&mut *agent);
+    expression_common.expression_LandingLightRumble();
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+    }
+}
+
+unsafe extern "C" fn expression_landingheavy(agent: &mut L2CAgentBase) {
+    let expression_common : &mut smash::lua2cpp::L2CFighterAnimcmdExpressionCommon = std::mem::transmute(&mut *agent);
+    expression_common.expression_LandingHeavyRumble();
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 2);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+    }
+    frame(agent.lua_state_agent, 21.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 6);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("expression_landinglight", expression_landinglight, Priority::Low);
+
+    agent.acmd("expression_landingheavy", expression_landingheavy, Priority::Low);
+}

--- a/fighters/koopajr/src/acmd/aerials.rs
+++ b/fighters/koopajr/src/acmd/aerials.rs
@@ -38,6 +38,33 @@ unsafe extern "C" fn game_attackairn(agent: &mut L2CAgentBase) {
     }
 }
 
+unsafe extern "C" fn expression_landingairf(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        ItemModule::set_have_item_visibility(agent.module_accessor, false, 0);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+    }
+    frame(agent.lua_state_agent, 2.0);
+    if macros::is_excute(agent) {
+        macros::RUMBLE_HIT(agent, Hash40::new("rbkind_attackm"), 0);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_impact"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+}
+
+unsafe extern "C" fn expression_landingairb(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        ItemModule::set_have_item_visibility(agent.module_accessor, false, 0);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+    }
+    frame(agent.lua_state_agent, 5.0);
+    if macros::is_excute(agent) {
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_impact"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+}
+
 pub fn install(agent: &mut Agent) {
     agent.acmd("game_attackairn", game_attackairn, Priority::Low);
+
+    agent.acmd("expression_landingairf", expression_landingairf, Priority::Low);
+
+    agent.acmd("expression_landingairb", expression_landingairb, Priority::Low);
 }

--- a/fighters/krool/src/acmd.rs
+++ b/fighters/krool/src/acmd.rs
@@ -2,9 +2,11 @@ use super::*;
 
 mod dash;
 
+mod landing;
+
 mod normals;
 mod smashes;
-// mod aerials;
+mod aerials;
 
 mod catch;
 
@@ -14,9 +16,11 @@ mod cliff;
 pub fn install(agent: &mut Agent) {
     dash::install(agent);
 
+    landing::install(agent);
+
     normals::install(agent);
     smashes::install(agent);
-    // aerials::install(agent);
+    aerials::install(agent);
 
     catch::install(agent);
 

--- a/fighters/krool/src/acmd/aerials.rs
+++ b/fighters/krool/src/acmd/aerials.rs
@@ -1,42 +1,69 @@
 use super::*;
 
-unsafe extern "C" fn game_attackairlw(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 4.0);
+unsafe extern "C" fn expression_landingairn(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
-        WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
-    }
-    frame(agent.lua_state_agent, 9.0);
-    macros::FT_MOTION_RATE(agent, 0.25);
-    frame(agent.lua_state_agent, 14.0);
-    macros::FT_MOTION_RATE(agent, 1.0);
-    if macros::is_excute(agent) {
-        WorkModule::on_flag(agent.module_accessor, *FIGHTER_KROOL_INSTANCE_WORK_ID_FLAG_REQUEST_WAIST_SHIELD_ON);
-        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 12.0, 270, 90, 0, 10, 7.0, 0.0, -1.5, 0.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
-        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 12.0, 270, 90, 0, 10, 8.5, 0.0, -6.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
-    }
-    frame(agent.lua_state_agent, 16.0);
-    if macros::is_excute(agent) {
-        macros::ATTACK(agent, 0, 0, Hash40::new("top"), 9.0, 361, 100, 0, 40, 6.5, 0.0, -1.5, 0.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
-        macros::ATTACK(agent, 1, 0, Hash40::new("top"), 9.0, 361, 100, 0, 40, 7.0, 0.0, -6.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 2);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_lands_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
     }
     frame(agent.lua_state_agent, 18.0);
     if macros::is_excute(agent) {
-        HitModule::set_status_all(agent.module_accessor, HitStatus(*HIT_STATUS_NORMAL), 0);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 5);
     }
-    frame(agent.lua_state_agent, 22.0);
+}
+
+unsafe extern "C" fn expression_landingairf(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
-        AttackModule::clear_all(agent.module_accessor);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 2);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_lands_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
     }
-    frame(agent.lua_state_agent, 26.0);
+    frame(agent.lua_state_agent, 18.0);
     if macros::is_excute(agent) {
-        WorkModule::on_flag(agent.module_accessor, *FIGHTER_KROOL_INSTANCE_WORK_ID_FLAG_REQUEST_WAIST_SHIELD_OFF);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 5);
     }
-    frame(agent.lua_state_agent, 40.0);
+}
+
+unsafe extern "C" fn expression_landingairb(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
-        WorkModule::off_flag(agent.module_accessor, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 2);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_lands_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 20.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 5);
+    }
+}
+
+unsafe extern "C" fn expression_landingairhi(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 5);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_lands_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+}
+
+unsafe extern "C" fn expression_landingairlw(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 2);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_landl_hv"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 18.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 5);
     }
 }
 
 pub fn install(agent: &mut Agent) {
-    agent.acmd("game_attackairlw", game_attackairlw, Priority::Low);
+    agent.acmd("expression_landingairn", expression_landingairn, Priority::Low);
+
+    agent.acmd("expression_landingairf", expression_landingairf, Priority::Low);
+
+    agent.acmd("expression_landingairb", expression_landingairb, Priority::Low);
+
+    agent.acmd("expression_landingairhi", expression_landingairhi, Priority::Low);
+
+    agent.acmd("expression_landingairlw", expression_landingairlw, Priority::Low);
 }

--- a/fighters/krool/src/acmd/landing.rs
+++ b/fighters/krool/src/acmd/landing.rs
@@ -1,0 +1,14 @@
+use super::*;
+
+unsafe extern "C" fn expression_landingheavy(agent: &mut L2CAgentBase) {
+    let expression_common : &mut smash::lua2cpp::L2CFighterAnimcmdExpressionCommon = std::mem::transmute(&mut *agent);
+    expression_common.expression_LandingHeavyRumble();
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("expression_landingheavy", expression_landingheavy, Priority::Low);
+}

--- a/fighters/plizardon/src/acmd.rs
+++ b/fighters/plizardon/src/acmd.rs
@@ -2,6 +2,8 @@ use super::*;
 
 mod dash;
 
+mod landing;
+
 mod normals;
 mod smashes;
 mod specials;
@@ -13,6 +15,8 @@ mod cliff;
 
 pub fn install(agent: &mut Agent) {
     dash::install(agent);
+
+    landing::install(agent);
 
     normals::install(agent);
     smashes::install(agent);

--- a/fighters/plizardon/src/acmd/landing.rs
+++ b/fighters/plizardon/src/acmd/landing.rs
@@ -1,0 +1,14 @@
+use super::*;
+
+unsafe extern "C" fn expression_landingheavy(agent: &mut L2CAgentBase) {
+    let expression_common : &mut smash::lua2cpp::L2CFighterAnimcmdExpressionCommon = std::mem::transmute(&mut *agent);
+    expression_common.expression_LandingHeavyRumble();
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("expression_landingheavy", expression_landingheavy, Priority::Low);
+}

--- a/fighters/wario/src/acmd.rs
+++ b/fighters/wario/src/acmd.rs
@@ -3,6 +3,7 @@ use super::*;
 mod dash;
 
 mod normals;
+mod aerials;
 mod specials;
 
 mod catch;
@@ -15,6 +16,7 @@ pub fn install(agent: &mut Agent) {
     dash::install(agent);
 
     normals::install(agent);
+    aerials::install(agent);
     specials::install(agent);
 
     catch::install(agent);

--- a/fighters/wario/src/acmd/aerials.rs
+++ b/fighters/wario/src/acmd/aerials.rs
@@ -1,0 +1,101 @@
+use super::*;
+
+unsafe extern "C" fn expression_landingairn(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_landl"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 2.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 2);
+    }
+    frame(agent.lua_state_agent, 4.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 4, true);
+    }
+    frame(agent.lua_state_agent, 17.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 6);
+    }
+}
+
+unsafe extern "C" fn expression_landingairf(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_landl"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 2.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 2);
+    }
+    frame(agent.lua_state_agent, 4.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 4, true);
+    }
+    frame(agent.lua_state_agent, 22.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 4);
+    }
+}
+
+unsafe extern "C" fn expression_landingairb(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_landl"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 2.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 2);
+    }
+    frame(agent.lua_state_agent, 4.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 4, true);
+    }
+    frame(agent.lua_state_agent, 19.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 4);
+    }
+}
+
+unsafe extern "C" fn expression_landingairhi(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_landl"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 2.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 2);
+    }
+    frame(agent.lua_state_agent, 4.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 4, true);
+    }
+    frame(agent.lua_state_agent, 15.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 7);
+    }
+}
+
+unsafe extern "C" fn expression_landingairlw(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        // macros::QUAKE(agent, *CAMERA_QUAKE_KIND_S);
+        ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_impact"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 3);
+    }
+    frame(agent.lua_state_agent, 19.0);
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 7);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("expression_landingairn", expression_landingairn, Priority::Low);
+
+    agent.acmd("expression_landingairf", expression_landingairf, Priority::Low);
+
+    agent.acmd("expression_landingairb", expression_landingairb, Priority::Low);
+
+    agent.acmd("expression_landingairhi", expression_landingairhi, Priority::Low);
+
+    agent.acmd("expression_landingairlw", expression_landingairlw, Priority::Low);
+}


### PR DESCRIPTION
Removes screen shake from the following:
- Heavy Landing for Heavies
- All aerials *except* for stall-and-fall down airs.