### PR TITLE
Disable Momentum Transfer + A Funny

### DIFF
--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -558,11 +558,7 @@ pub mod luigi {
 pub mod mario {
     pub mod instance {
         pub mod flag {
-            pub const SPECIAL_LW_BLJ_PREV : i32 = 0x0100;
-            pub const BONKER : i32 = 0x0101;
-        }
-        pub mod int {
-            pub const SPECIAL_LW_KIND : i32 = 0x0100;
+            pub const BONKER : i32 = 0x0100;
         }
     }
     pub mod status {
@@ -573,21 +569,16 @@ pub mod mario {
             pub const SPECIAL_S_HOP : i32 = 0x1151;
             pub const SPECIAL_S_ENABLE_CONTROL : i32 = 0x1152;
 
-            pub const SPECIAL_LW_LANDING : i32 = 0x1150;
-            pub const SPECIAL_LW_BLJ : i32 = 0x1151;
+            pub const SPECIAL_LW_IS_BLJ : i32 = 0x1150;
         }
-        pub mod int {
-            pub const SPECIAL_LW_LONG_JUMP_KIND : i32 = 0x1150;
-        }
-    }
-    pub const SPECIAL_LW_KIND_LONG_JUMP : i32 = 0;
-    pub const SPECIAL_LW_KIND_GROUND_POUND : i32 = 1;
-    pub const SPECIAL_LW_KIND_GROUND_POUND_CANCEL : i32 = 2;
 
-    pub const LONG_JUMP_W : i32 = 0;
-    pub const LONG_JUMP_M : i32 = 1;
-    pub const LONG_JUMP_S : i32 = 2;
-    pub const LONG_JUMP_B : i32 = 3;
+        pub const SPECIAL_LW_JUMP : i32 = 0x1E3;
+        pub const SPECIAL_LW_LANDING : i32 = 0x1E4;
+        pub const SPECIAL_AIR_LW_START : i32 = 0x1E5;
+        pub const SPECIAL_AIR_LW_FALL : i32 = 0x1E6;
+        pub const SPECIAL_AIR_LW_LANDING : i32 = 0x1E7;
+        pub const SPECIAL_AIR_LW_CANCEL : i32 = 0x1E8;
+    }
 }
 
 pub mod mariod {

--- a/fighters/common/src/energy/control.rs
+++ b/fighters/common/src/energy/control.rs
@@ -312,9 +312,6 @@ unsafe extern "C" fn update(energy: &mut FighterKineticEnergyControl, module_acc
 
     let accel_diff = match reset_type {
         FallAdjust | FallAdjustNoCap | FlyAdjust | ShootDash | ShootBackDash | RevolveSlashAir | MoveGround | MoveAir => {
-            if energy.speed.x.abs() > energy.speed_max.x {
-                energy.speed_brake.x *= 1.5;
-            }
             accel_add_x * stick.x.signum() + stick.x * energy.accel_mul_x
         },
         WallJump => {

--- a/fighters/common/src/energy/control.rs
+++ b/fighters/common/src/energy/control.rs
@@ -757,21 +757,25 @@ unsafe extern "C" fn setup(energy: &mut FighterKineticEnergyControl, reset_type:
             if reset_type != FallAdjustNoCap
             && !WorkModule::is_flag(module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_NO_LIMIT)
             && energy.unk[2] == 0 {
-                let is_jump = VarModule::is_flag(module_accessor, vars::fighter::instance::flag::JUMP_FROM_SQUAT);
-                let break_limit = is_jump || StatusModule::prev_situation_kind(module_accessor) == *SITUATION_KIND_AIR;
-                let limit_speed = if break_limit {
-                    let mut limit_speed = WorkModule::get_param_float(module_accessor, hash40("air_speed_x_stable"), 0) * 1.4;
-                    let run_speed = WorkModule::get_param_float(module_accessor, hash40("run_speed_max"), 0);
-                    let dash_speed = WorkModule::get_param_float(module_accessor, hash40("dash_speed"), 0);
-                    let ground_speed = run_speed.max(dash_speed);
-                    if limit_speed > ground_speed {
-                        limit_speed = ground_speed + ((limit_speed - ground_speed) / 2.0);
-                    }
-                    limit_speed.clamp(1.2, 1.7)
-                }
-                else {
-                    WorkModule::get_param_float(module_accessor, hash40("air_speed_x_stable"), 0)
-                };
+                // let is_jump = VarModule::is_flag(module_accessor, vars::fighter::instance::flag::JUMP_FROM_SQUAT);
+                // let break_limit = is_jump || StatusModule::prev_situation_kind(module_accessor) == *SITUATION_KIND_AIR;
+                // let limit_speed = if break_limit {
+                //     let mut limit_speed = WorkModule::get_param_float(module_accessor, hash40("air_speed_x_stable"), 0) * 1.4;
+                //     let run_speed = WorkModule::get_param_float(module_accessor, hash40("run_speed_max"), 0);
+                //     let dash_speed = WorkModule::get_param_float(module_accessor, hash40("dash_speed"), 0);
+                //     let ground_speed = run_speed.max(dash_speed);
+                //     if limit_speed > ground_speed {
+                //         limit_speed = ground_speed + ((limit_speed - ground_speed) / 2.0);
+                //     }
+                //     limit_speed.clamp(1.2, 1.7)
+                // }
+                // else {
+                //     WorkModule::get_param_float(module_accessor, hash40("air_speed_x_stable"), 0)
+                // };
+                // if limit_speed < energy.speed.x.abs() {
+                //     energy.speed = PaddedVec2::new(limit_speed * energy.speed.x.signum(), 0.0);
+                // }
+                let limit_speed = WorkModule::get_param_float(module_accessor, hash40("air_speed_x_stable"), 0);
                 if limit_speed < energy.speed.x.abs() {
                     energy.speed = PaddedVec2::new(limit_speed * energy.speed.x.signum(), 0.0);
                 }

--- a/fighters/mario/src/acmd/specials.rs
+++ b/fighters/mario/src/acmd/specials.rs
@@ -173,29 +173,10 @@ unsafe extern "C" fn game_specialhi(agent: &mut L2CAgentBase) {
 }
 
 unsafe extern "C" fn game_longjump(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 2.0);
-    if macros::is_excute(agent) {
-        if VarModule::get_int(agent.module_accessor, vars::mario::status::int::SPECIAL_LW_LONG_JUMP_KIND) == vars::mario::LONG_JUMP_B {
-            VarModule::on_flag(agent.module_accessor, vars::mario::status::flag::SPECIAL_LW_LANDING);
-        }
-    }
     frame(agent.lua_state_agent, 6.0);
-    if macros::is_excute(agent) {
-        VarModule::on_flag(agent.module_accessor, vars::mario::status::flag::SPECIAL_LW_LANDING);
-        if [vars::mario::LONG_JUMP_B, vars::mario::LONG_JUMP_M].contains(&VarModule::get_int(agent.module_accessor, vars::mario::status::int::SPECIAL_LW_LONG_JUMP_KIND)) {
-            CancelModule::enable_cancel(agent.module_accessor);
-        }
-    }
-    frame(agent.lua_state_agent, 15.0);
-    if macros::is_excute(agent) {
-        if VarModule::get_int(agent.module_accessor, vars::mario::status::int::SPECIAL_LW_LONG_JUMP_KIND) == vars::mario::LONG_JUMP_W {
-            CancelModule::enable_cancel(agent.module_accessor);
-        }
-    }
-    frame(agent.lua_state_agent, 20.0);
-    if macros::is_excute(agent) {
-        if VarModule::get_int(agent.module_accessor, vars::mario::status::int::SPECIAL_LW_LONG_JUMP_KIND) == vars::mario::LONG_JUMP_S {
-            CancelModule::enable_cancel(agent.module_accessor);
+    if VarModule::is_flag(agent.module_accessor, vars::mario::status::flag::SPECIAL_LW_IS_BLJ) {
+        if macros::is_excute(agent) {
+            macros::ATTACK(agent, 0, 0, Hash40::new("top"), 3.0, 45, 60, 0, 64, 3.0, 0.0, 5.0, 1.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_B, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
         }
     }
 }
@@ -209,6 +190,12 @@ unsafe extern "C" fn sound_longjump(agent: &mut L2CAgentBase) {
 unsafe extern "C" fn expression_longjump(agent: &mut L2CAgentBase) {
     if macros::is_excute(agent) {
         ControlModule::set_rumble(agent.module_accessor, Hash40::new("rbkind_jump"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(agent.lua_state_agent, 6.0);
+    if VarModule::is_flag(agent.module_accessor, vars::mario::status::flag::SPECIAL_LW_IS_BLJ) {
+        if macros::is_excute(agent) {
+            macros::RUMBLE_HIT(agent, Hash40::new("rbkind_attackl"), 0);
+        }
     }
 }
 

--- a/fighters/mario/src/agent_init.rs
+++ b/fighters/mario/src/agent_init.rs
@@ -1,14 +1,12 @@
 use super::*;
 
-unsafe extern "C" fn mario_speciallw_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if VarModule::get_int(fighter.module_accessor, vars::mario::instance::int::SPECIAL_LW_KIND) == vars::mario::SPECIAL_LW_KIND_GROUND_POUND_CANCEL {
-        return 0.into();
-    }
-    1.into()
+extern "C" {
+    #[link_name = "speciallw_pre_generic"]
+    fn speciallw_pre_generic(fighter: &mut L2CFighterCommon) -> L2CValue;
 }
 
 unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {
-    fighter.global_table[CHECK_SPECIAL_LW_UNIQ].assign(&L2CValue::Ptr(mario_speciallw_pre as *const () as _));
+    fighter.global_table[CHECK_SPECIAL_LW_UNIQ].assign(&L2CValue::Ptr(speciallw_pre_generic as *const () as _));
 }
 
 pub fn install(agent: &mut Agent) {

--- a/fighters/mario/src/frame.rs
+++ b/fighters/mario/src/frame.rs
@@ -17,14 +17,9 @@ unsafe extern "C" fn mario_attack_air_lw_bounce(fighter: &mut L2CFighterCommon) 
 
 unsafe extern "C" fn mario_reset_special_lw_kind(fighter: &mut L2CFighterCommon) {
     if StatusModule::situation_kind(fighter.module_accessor) == *SITUATION_KIND_GROUND
-    || StatusModule::situation_kind(fighter.module_accessor) == *SITUATION_KIND_CLIFF {
-        if ![
-            *FIGHTER_STATUS_KIND_SPECIAL_LW,
-            *FIGHTER_MARIO_STATUS_KIND_SPECIAL_LW_SHOOT,
-            *FIGHTER_MARIO_STATUS_KIND_SPECIAL_LW_CHARGE
-        ].contains(&StatusModule::status_kind(fighter.module_accessor)) {
-            VarModule::set_int(fighter.module_accessor, vars::mario::instance::int::SPECIAL_LW_KIND, vars::mario::SPECIAL_LW_KIND_LONG_JUMP);
-        }
+    || StatusModule::situation_kind(fighter.module_accessor) == *SITUATION_KIND_CLIFF
+    || fighter.global_table[STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_REBIRTH {
+        VarModule::off_flag(fighter.module_accessor, vars::fighter::instance::flag::DISABLE_SPECIAL_LW);
     }
 }
 

--- a/fighters/mario/src/status.rs
+++ b/fighters/mario/src/status.rs
@@ -1,15 +1,37 @@
 use super::*;
 
 mod attack_s4;
+
 mod attack_air;
+
 mod special_s;
+
 mod special_lw;
+mod special_lw_jump;
+mod special_lw_landing;
+
+mod special_air_lw;
+mod special_air_lw_fall;
+mod special_air_lw_landing;
+mod special_air_lw_cancel;
+
 mod rebirth;
 
 pub fn install(agent: &mut Agent) {
     attack_s4::install(agent);
+
     attack_air::install(agent);
+
     special_s::install(agent);
+
     special_lw::install(agent);
+    special_lw_jump::install(agent);
+    special_lw_landing::install(agent);
+
+    special_air_lw::install(agent);
+    special_air_lw_fall::install(agent);
+    special_air_lw_landing::install(agent);
+    special_air_lw_cancel::install(agent);
+
     rebirth::install(agent);
 }

--- a/fighters/mario/src/status/special_air_lw.rs
+++ b/fighters/mario/src/status/special_air_lw.rs
@@ -1,15 +1,11 @@
 use super::*;
 
-unsafe extern "C" fn special_lw_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_GROUND {
-        StatusModule::set_status_kind_interrupt(fighter.module_accessor, vars::mario::status::SPECIAL_AIR_LW_START);
-        return 1.into();
-    }
+unsafe extern "C" fn special_air_lw_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
     StatusModule::init_settings(
         fighter.module_accessor,
-        SituationKind(*SITUATION_KIND_GROUND),
+        SituationKind(*SITUATION_KIND_AIR),
         *FIGHTER_KINETIC_TYPE_UNIQ,
-        *GROUND_CORRECT_KIND_GROUND as u32,
+        *GROUND_CORRECT_KIND_AIR as u32,
         GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
         true,
         *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
@@ -36,10 +32,10 @@ unsafe extern "C" fn special_lw_pre(fighter: &mut L2CFighterCommon) -> L2CValue 
     0.into()
 }
 
-unsafe extern "C" fn mario_special_lw_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+unsafe extern "C" fn special_air_lw_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     MotionModule::change_motion(
         fighter.module_accessor,
-        Hash40::new("special_lw_start"),
+        Hash40::new("special_air_lw_start"),
         0.0,
         1.0,
         false,
@@ -47,17 +43,17 @@ unsafe extern "C" fn mario_special_lw_main(fighter: &mut L2CFighterCommon) -> L2
         false,
         false
     );
-    fighter.sub_shift_status_main(L2CValue::Ptr(mario_special_lw_main_loop as *const () as _))
+    fighter.sub_shift_status_main(L2CValue::Ptr(special_air_lw_main_loop as *const () as _))
 }
 
-unsafe extern "C" fn mario_special_lw_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+unsafe extern "C" fn special_air_lw_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
     if MotionModule::is_end(fighter.module_accessor) {
-        fighter.change_status(vars::mario::status::SPECIAL_LW_JUMP.into(), false.into());
+        fighter.change_status(vars::mario::status::SPECIAL_AIR_LW_FALL.into(), false.into());
     }
     0.into()
 }
 
 pub fn install(agent: &mut Agent) {
-    agent.status(Pre, *FIGHTER_STATUS_KIND_SPECIAL_LW, special_lw_pre);
-    agent.status(Main, *FIGHTER_STATUS_KIND_SPECIAL_LW, mario_special_lw_main);
+    agent.status(Pre, vars::mario::status::SPECIAL_AIR_LW_START, special_air_lw_pre);
+    agent.status(Main, vars::mario::status::SPECIAL_AIR_LW_START, special_air_lw_main);
 }

--- a/fighters/mario/src/status/special_air_lw_cancel.rs
+++ b/fighters/mario/src/status/special_air_lw_cancel.rs
@@ -1,0 +1,106 @@
+use super::*;
+
+unsafe extern "C" fn special_air_lw_cancel_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_AIR),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_AIR as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        (
+            *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK |
+            *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_LW
+        ) as u64,
+        0,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_LW as u32,
+        0
+    );
+    0.into()
+}
+
+unsafe extern "C" fn special_air_lw_cancel_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+    let speed_y = sv_kinetic_energy::get_speed_y(fighter.lua_state_agent).max(-0.5);
+
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        ENERGY_GRAVITY_RESET_TYPE_GRAVITY,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    );
+    sv_kinetic_energy!(
+        set_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        speed_y
+    );
+
+    KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+
+    KineticUtility::reset_enable_energy(
+        *FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+        fighter.module_accessor,
+        *ENERGY_CONTROLLER_RESET_TYPE_FALL_ADJUST,
+        &Vector2f{x: 0.0, y: 0.0},
+        &Vector3f{x: 0.0, y: 0.0, z: 0.0},
+    );
+
+    0.into()
+}
+
+unsafe extern "C" fn special_air_lw_cancel_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    VarModule::on_flag(fighter.module_accessor, vars::fighter::instance::flag::DISABLE_SPECIAL_LW);
+
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("special_air_lw_cancel"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+    fighter.sub_shift_status_main(L2CValue::Ptr(special_air_lw_cancel_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn special_air_lw_cancel_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.sub_transition_group_check_air_cliff().get_bool() {
+        return 1.into();
+    }
+
+    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        fighter.change_status(FIGHTER_STATUS_KIND_LANDING.into(), false.into());
+        return 0.into();
+    } 
+
+    if MotionModule::is_end(fighter.module_accessor) {
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+    }
+    0.into()
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Pre, vars::mario::status::SPECIAL_AIR_LW_CANCEL, special_air_lw_cancel_pre);
+    agent.status(Init, vars::mario::status::SPECIAL_AIR_LW_CANCEL, special_air_lw_cancel_init);
+    agent.status(Main, vars::mario::status::SPECIAL_AIR_LW_CANCEL, special_air_lw_cancel_main);
+}

--- a/fighters/mario/src/status/special_air_lw_fall.rs
+++ b/fighters/mario/src/status/special_air_lw_fall.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+unsafe extern "C" fn special_air_lw_fall_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_AIR),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_AIR as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_ALWAYS),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        (
+            *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK |
+            *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_LW
+        ) as u64,
+        0,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_LW as u32,
+        0
+    );
+    0.into()
+}
+
+unsafe extern "C" fn special_air_lw_fall_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    KineticUtility::clear_unable_energy(*FIGHTER_KINETIC_ENERGY_ID_CONTROL, fighter.module_accessor);
+
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        ENERGY_GRAVITY_RESET_TYPE_GRAVITY,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    );
+    sv_kinetic_energy!(
+        set_stable_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        vl::param_special_lw::ground_pound_fall_speed
+    );
+    sv_kinetic_energy!(
+        set_limit_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        vl::param_special_lw::ground_pound_fall_speed
+    );
+    sv_kinetic_energy!(
+        set_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        -vl::param_special_lw::ground_pound_fall_speed
+    );
+    sv_kinetic_energy!(
+        set_accel,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        -0.2
+    );
+
+    KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+
+    0.into()
+}
+
+unsafe extern "C" fn special_air_lw_fall_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("special_air_lw_fall"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+    fighter.sub_shift_status_main(L2CValue::Ptr(special_air_lw_fall_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn special_air_lw_fall_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.sub_transition_group_check_air_cliff().get_bool() {
+        return 1.into();
+    }
+
+    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        fighter.change_status(vars::mario::status::SPECIAL_AIR_LW_LANDING.into(), false.into());
+        return 1.into();
+    }
+
+    if fighter.global_table[STICK_Y].get_f32() >= 0.5 {
+        fighter.change_status(vars::mario::status::SPECIAL_AIR_LW_CANCEL.into(), false.into());
+        return 1.into();
+    }
+
+    0.into()
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Pre, vars::mario::status::SPECIAL_AIR_LW_FALL, special_air_lw_fall_pre);
+    agent.status(Init, vars::mario::status::SPECIAL_AIR_LW_FALL, special_air_lw_fall_init);
+    agent.status(Main, vars::mario::status::SPECIAL_AIR_LW_FALL, special_air_lw_fall_main);
+}

--- a/fighters/mario/src/status/special_air_lw_landing.rs
+++ b/fighters/mario/src/status/special_air_lw_landing.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+unsafe extern "C" fn special_air_lw_landing_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_GROUND),
+        *FIGHTER_KINETIC_TYPE_GROUND_STOP,
+        *GROUND_CORRECT_KIND_GROUND as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        (
+            *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK |
+            *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_LW
+        ) as u64,
+        0,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_LW as u32,
+        0
+    );
+    0.into()
+}
+
+unsafe extern "C" fn special_air_lw_landing_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("special_air_lw_landing"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+    fighter.sub_shift_status_main(L2CValue::Ptr(special_air_lw_landing_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn special_air_lw_landing_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if CancelModule::is_enable_cancel(fighter.module_accessor) {
+        if fighter.sub_wait_ground_check_common(false.into()).get_bool()
+        || fighter.sub_air_check_fall_common().get_bool() {
+            return 1.into();
+        }
+    }
+    if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_GROUND {
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+    }
+    if MotionModule::is_end(fighter.module_accessor) {
+        fighter.change_status(FIGHTER_STATUS_KIND_WAIT.into(), false.into());
+    }
+    0.into()
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Pre, vars::mario::status::SPECIAL_AIR_LW_LANDING, special_air_lw_landing_pre);
+    agent.status(Main, vars::mario::status::SPECIAL_AIR_LW_LANDING, special_air_lw_landing_main);
+}

--- a/fighters/mario/src/status/special_lw_jump.rs
+++ b/fighters/mario/src/status/special_lw_jump.rs
@@ -1,0 +1,151 @@
+use super::*;
+use super::super::vl;
+
+unsafe extern "C" fn special_lw_jump_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_AIR),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_AIR as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_ALWAYS),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        (
+            *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK |
+            *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_LW
+        ) as u64,
+        0,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_LW as u32,
+        0
+    );
+    0.into()
+}
+
+unsafe extern "C" fn special_lw_jump_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let stick_x = fighter.global_table[STICK_X].get_f32();
+    let lr = PostureModule::lr(fighter.module_accessor);
+    let sum_speed_x = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+
+    let is_blj = fighter.global_table[PREV_STATUS_KIND].get_i32() != *FIGHTER_STATUS_KIND_SPECIAL_LW
+        && sum_speed_x * lr < 0.0
+        && stick_x * lr < 0.0;
+    
+    VarModule::set_flag(fighter.module_accessor, vars::mario::status::flag::SPECIAL_LW_IS_BLJ, is_blj);
+
+    let speed_x = if sum_speed_x * lr >= 0.0 && sum_speed_x.abs() < vl::param_special_lw::long_jump_speed_min_x {
+        vl::param_special_lw::long_jump_speed_min_x * lr
+    }
+    else {
+        sum_speed_x * 1.5
+    };
+
+    KineticUtility::clear_unable_energy(*FIGHTER_KINETIC_ENERGY_ID_STOP, fighter.module_accessor);
+
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+        ENERGY_CONTROLLER_RESET_TYPE_FALL_ADJUST,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    );
+    sv_kinetic_energy!(
+        set_limit_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+        5.0,
+        -1.0
+    );
+    sv_kinetic_energy!(
+        set_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+        speed_x,
+        0.0
+    );
+
+    KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        ENERGY_GRAVITY_RESET_TYPE_GRAVITY,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    );
+
+    let speed_y = if is_blj {
+        vl::param_special_lw::long_jump_speed_y_back
+    }
+    else {
+        vl::param_special_lw::long_jump_speed_y
+    };
+    sv_kinetic_energy!(
+        set_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        speed_y
+    );
+
+    KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+    0.into()
+}
+
+unsafe extern "C" fn special_lw_jump_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("special_lw_jump"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+    fighter.sub_shift_status_main(L2CValue::Ptr(special_lw_jump_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn special_lw_jump_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    special_lw_jump_power_handler(fighter);
+
+    if CancelModule::is_enable_cancel(fighter.module_accessor) {
+        if fighter.sub_air_check_fall_common().get_bool() {
+            return 1.into();
+        }
+    }
+    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        fighter.change_status(vars::mario::status::SPECIAL_LW_LANDING.into(), false.into());
+    }
+    0.into()
+}
+
+unsafe extern "C" fn special_lw_jump_power_handler(fighter: &mut L2CFighterCommon) {
+    if AttackModule::is_attack(fighter.module_accessor, 0, false) {
+        let sum_speed_x = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN).abs();
+        AttackModule::set_power(fighter.module_accessor, 0, 4.0 * sum_speed_x, false);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Pre, vars::mario::status::SPECIAL_LW_JUMP, special_lw_jump_pre);
+    agent.status(Init, vars::mario::status::SPECIAL_LW_JUMP, special_lw_jump_init);
+    agent.status(Main, vars::mario::status::SPECIAL_LW_JUMP, special_lw_jump_main);
+}

--- a/fighters/mario/src/status/special_lw_landing.rs
+++ b/fighters/mario/src/status/special_lw_landing.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+unsafe extern "C" fn special_lw_landing_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_GROUND),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_GROUND as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        (
+            *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK |
+            *FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_LW
+        ) as u64,
+        0,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_LW as u32,
+        0
+    );
+    0.into()
+}
+
+unsafe extern "C" fn special_lw_landing_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let sum_speed_x = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+
+    KineticUtility::clear_unable_energy(*FIGHTER_KINETIC_ENERGY_ID_GRAVITY, fighter.module_accessor);
+    KineticUtility::clear_unable_energy(*FIGHTER_KINETIC_ENERGY_ID_CONTROL, fighter.module_accessor);
+
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP,
+        ENERGY_STOP_RESET_TYPE_GROUND,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    );
+    sv_kinetic_energy!(
+        set_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP,
+        sum_speed_x,
+        0.0
+    );
+    sv_kinetic_energy!(
+        set_limit_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP,
+        -1.0,
+        -1.0
+    );
+
+    KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_STOP);
+
+    0.into()
+}
+
+unsafe extern "C" fn special_lw_landing_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("special_lw_landing"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW);
+
+    fighter.sub_shift_status_main(L2CValue::Ptr(special_lw_landing_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn special_lw_landing_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW)
+    && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_LW != 0 {
+        fighter.change_status(vars::mario::status::SPECIAL_LW_JUMP.into(), true.into());
+        return 1.into();
+    }
+
+    if CancelModule::is_enable_cancel(fighter.module_accessor) {
+        if fighter.sub_wait_ground_check_common(false.into()).get_bool()
+        || fighter.sub_air_check_fall_common().get_bool() {
+            return 1.into();
+        }
+    }
+    if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_GROUND {
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+    }
+
+    if MotionModule::is_end(fighter.module_accessor) {
+        fighter.change_status(FIGHTER_STATUS_KIND_WAIT.into(), false.into());
+    }
+    0.into()
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Pre, vars::mario::status::SPECIAL_LW_LANDING, special_lw_landing_pre);
+    agent.status(Init, vars::mario::status::SPECIAL_LW_LANDING, special_lw_landing_init);
+    agent.status(Main, vars::mario::status::SPECIAL_LW_LANDING, special_lw_landing_main);
+}

--- a/fighters/mario/src/vl.rs
+++ b/fighters/mario/src/vl.rs
@@ -7,13 +7,8 @@ pub mod param_special_s {
 }
 
 pub mod param_special_lw {
-    pub const long_jump_speed_weak_x : f32 = 1.1;
-    pub const long_jump_speed_weak_y : f32 = 1.4;
-    pub const long_jump_speed_mid_x : f32 = 1.4;
-    pub const long_jump_speed_mid_y : f32 = 1.4;
-    pub const long_jump_speed_strong_x : f32 = 1.7;
-    pub const long_jump_speed_strong_y : f32 = 1.6;
-    pub const long_jump_air_accel_x_mul : f32 = 0.6;
-    pub const long_jump_air_accel_y_mul : f32 = 0.4;
+    pub const long_jump_speed_min_x : f32 = 0.8;
+    pub const long_jump_speed_y : f32 = 1.6;
+    pub const long_jump_speed_y_back : f32 = 0.2;
     pub const ground_pound_fall_speed : f32 = 4.0;
 }


### PR DESCRIPTION
# Changelog

## Engine
- Removes momentum transfer from the game. I felt that it didn't make enough of an impact to gamefeel to need to exist.

## Mario
- Rewrote Long Jump and Down Special.
- Long Jump now functions closer to Super Mario 64, multiplying your momentum by 1.5x when performed unless performed at a standstill.
  - Due to these changes, it is now possible to massively increase your speed while performing the BLJ.
  - BLJ also has a funny speed-based hitbox if performed while going off of the stage.