### PR TITLE
Ledge Grab Aesthetic Change

### DIFF
--- a/fighters/bayonetta/src/acmd/cliff.rs
+++ b/fighters/bayonetta/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/brave/src/acmd/cliff.rs
+++ b/fighters/brave/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/buddy/src/acmd/cliff.rs
+++ b/fighters/buddy/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/captain/src/acmd/cliff.rs
+++ b/fighters/captain/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/chrom/src/acmd/cliff.rs
+++ b/fighters/chrom/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/cloud/src/acmd/cliff.rs
+++ b/fighters/cloud/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/daisy/src/acmd/cliff.rs
+++ b/fighters/daisy/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/dedede/src/acmd/cliff.rs
+++ b/fighters/dedede/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/demon/src/acmd/cliff.rs
+++ b/fighters/demon/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/diddy/src/acmd/cliff.rs
+++ b/fighters/diddy/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/dolly/src/acmd/cliff.rs
+++ b/fighters/dolly/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/donkey/src/acmd/cliff.rs
+++ b/fighters/donkey/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/duckhunt/src/acmd/cliff.rs
+++ b/fighters/duckhunt/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/edge/src/acmd/cliff.rs
+++ b/fighters/edge/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/eflame/src/acmd/cliff.rs
+++ b/fighters/eflame/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/elight/src/acmd/cliff.rs
+++ b/fighters/elight/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/falco/src/acmd/cliff.rs
+++ b/fighters/falco/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/fox/src/acmd/cliff.rs
+++ b/fighters/fox/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/gamewatch/src/acmd/cliff.rs
+++ b/fighters/gamewatch/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 6.0);
+    macros::FT_MOTION_RATE(agent, 6.0 / 14.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/ganon/src/acmd/cliff.rs
+++ b/fighters/ganon/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/gaogaen/src/acmd/cliff.rs
+++ b/fighters/gaogaen/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/gekkouga/src/acmd/cliff.rs
+++ b/fighters/gekkouga/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/iceclimber/src/acmd/cliff.rs
+++ b/fighters/iceclimber/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/ike/src/acmd/cliff.rs
+++ b/fighters/ike/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/inkling/src/acmd/cliff.rs
+++ b/fighters/inkling/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/jack/src/acmd/cliff.rs
+++ b/fighters/jack/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/kamui/src/acmd/cliff.rs
+++ b/fighters/kamui/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/ken/src/acmd/cliff.rs
+++ b/fighters/ken/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/kirby/src/acmd/cliff.rs
+++ b/fighters/kirby/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/koopa/src/acmd/cliff.rs
+++ b/fighters/koopa/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/koopajr/src/acmd/cliff.rs
+++ b/fighters/koopajr/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/krool/src/acmd/cliff.rs
+++ b/fighters/krool/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/link/src/acmd/cliff.rs
+++ b/fighters/link/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/littlemac/src/acmd/cliff.rs
+++ b/fighters/littlemac/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/lucario/src/acmd/cliff.rs
+++ b/fighters/lucario/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/lucas/src/acmd/cliff.rs
+++ b/fighters/lucas/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/lucina/src/acmd/cliff.rs
+++ b/fighters/lucina/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/luigi/src/acmd/cliff.rs
+++ b/fighters/luigi/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/mario/src/acmd/cliff.rs
+++ b/fighters/mario/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/mariod/src/acmd/cliff.rs
+++ b/fighters/mariod/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/marth/src/acmd/cliff.rs
+++ b/fighters/marth/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/master/src/acmd/cliff.rs
+++ b/fighters/master/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/metaknight/src/acmd/cliff.rs
+++ b/fighters/metaknight/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/mewtwo/src/acmd/cliff.rs
+++ b/fighters/mewtwo/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/miifighter/src/acmd/cliff.rs
+++ b/fighters/miifighter/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/miigunner/src/acmd/cliff.rs
+++ b/fighters/miigunner/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/miiswordsman/src/acmd/cliff.rs
+++ b/fighters/miiswordsman/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/murabito/src/acmd/cliff.rs
+++ b/fighters/murabito/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/ness/src/acmd/cliff.rs
+++ b/fighters/ness/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/packun/src/acmd/cliff.rs
+++ b/fighters/packun/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/pacman/src/acmd/cliff.rs
+++ b/fighters/pacman/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/palutena/src/acmd/cliff.rs
+++ b/fighters/palutena/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/peach/src/acmd/cliff.rs
+++ b/fighters/peach/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/pfushigisou/src/acmd/cliff.rs
+++ b/fighters/pfushigisou/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/pichu/src/acmd/cliff.rs
+++ b/fighters/pichu/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/pickel/src/acmd/cliff.rs
+++ b/fighters/pickel/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/pikachu/src/acmd/cliff.rs
+++ b/fighters/pikachu/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/pikmin/src/acmd/cliff.rs
+++ b/fighters/pikmin/src/acmd/cliff.rs
@@ -2,7 +2,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/pit/src/acmd/cliff.rs
+++ b/fighters/pit/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/pitb/src/acmd/cliff.rs
+++ b/fighters/pitb/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/plizardon/src/acmd/cliff.rs
+++ b/fighters/plizardon/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/purin/src/acmd/cliff.rs
+++ b/fighters/purin/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/pzenigame/src/acmd/cliff.rs
+++ b/fighters/pzenigame/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/reflet/src/acmd/cliff.rs
+++ b/fighters/reflet/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/richter/src/acmd/cliff.rs
+++ b/fighters/richter/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/ridley/src/acmd/cliff.rs
+++ b/fighters/ridley/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/robot/src/acmd/cliff.rs
+++ b/fighters/robot/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/rockman/src/acmd/cliff.rs
+++ b/fighters/rockman/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/rosetta/src/acmd/cliff.rs
+++ b/fighters/rosetta/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/roy/src/acmd/cliff.rs
+++ b/fighters/roy/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/ryu/src/acmd/cliff.rs
+++ b/fighters/ryu/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/samus/src/acmd/cliff.rs
+++ b/fighters/samus/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/samusd/src/acmd/cliff.rs
+++ b/fighters/samusd/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/sheik/src/acmd/cliff.rs
+++ b/fighters/sheik/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/shizue/src/acmd/cliff.rs
+++ b/fighters/shizue/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/shulk/src/acmd/cliff.rs
+++ b/fighters/shulk/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/simon/src/acmd/cliff.rs
+++ b/fighters/simon/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/snake/src/acmd/cliff.rs
+++ b/fighters/snake/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/sonic/src/acmd/cliff.rs
+++ b/fighters/sonic/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/szerosuit/src/acmd/cliff.rs
+++ b/fighters/szerosuit/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/tantan/src/acmd/cliff.rs
+++ b/fighters/tantan/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/template/src/acmd/cliff.rs
+++ b/fighters/template/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/toonlink/src/acmd/cliff.rs
+++ b/fighters/toonlink/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/trail/src/acmd/cliff.rs
+++ b/fighters/trail/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/wario/src/acmd/cliff.rs
+++ b/fighters/wario/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/wiifit/src/acmd/cliff.rs
+++ b/fighters/wiifit/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/wolf/src/acmd/cliff.rs
+++ b/fighters/wolf/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/yoshi/src/acmd/cliff.rs
+++ b/fighters/yoshi/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/younglink/src/acmd/cliff.rs
+++ b/fighters/younglink/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }

--- a/fighters/zelda/src/acmd/cliff.rs
+++ b/fighters/zelda/src/acmd/cliff.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn game_cliffcatch(agent: &mut L2CAgentBase) {
-    frame(agent.lua_state_agent, 11.0);
+    frame(agent.lua_state_agent, 2.0);
+    macros::FT_MOTION_RATE(agent, 10.0 / 18.0);
+    frame(agent.lua_state_agent, 20.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(agent.module_accessor, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
     }


### PR DESCRIPTION
Ledge Grab now speeds up the animation to finish in 12 frames instead of allowing you to cancel it after 12 frames.

Fixes issues where characters would snap upwards sometimes if canceled too early. Ex. Ryu/Ken and Neutral Ledge Getup