### PR TITLE
Jab > Tilt Cancel Nerf

### DIFF
--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -133,6 +133,7 @@ pub mod appeal {
 pub mod attack {
     pub mod flag {
         pub const INVALID_HOLD_INPUT : i32 = 0x1051;
+        pub const ATTACK_S3_IS_REVERSE : i32 = 0x1052;
     }
 }
 


### PR DESCRIPTION
# Changelog

- When canceling Jabs into Tilts, you can no longer reverse the tilt - doing so will instead do nothing.