### PR TITLE
Air Dodge Adjustments

### DIFF
--- a/fighters/common/src/status/escape/escape_air.rs
+++ b/fighters/common/src/status/escape/escape_air.rs
@@ -460,6 +460,8 @@ pub unsafe extern "C" fn exec_escape_air_slide(fighter: &mut L2CFighterCommon) {
             EffectModule::set_rate(fighter.module_accessor, line, 0.5);
 
             SoundModule::play_se(fighter.module_accessor, Hash40::new("se_common_airdash"), true, false, false, false, enSEType(0));
+
+            fighter.sub_fighter_cliff_check(GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES.into());
         }
         if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE_ENABLE_GRAVITY) {
             let tier = get_airdash_tier(fighter);

--- a/fighters/common/src/status/sub_fighter.rs
+++ b/fighters/common/src/status/sub_fighter.rs
@@ -16,7 +16,9 @@ unsafe extern "C" fn sub_fighter_pre_end_status(fighter: &mut L2CFighterCommon) 
                 *FIGHTER_STATUS_KIND_SPECIAL_N,
                 *FIGHTER_STATUS_KIND_SPECIAL_S,
                 *FIGHTER_STATUS_KIND_SPECIAL_HI,
-                *FIGHTER_STATUS_KIND_SPECIAL_LW
+                *FIGHTER_STATUS_KIND_SPECIAL_LW,
+                *FIGHTER_STATUS_KIND_ESCAPE_AIR, // new
+                *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE // new
             ].contains(&status) {
                 let air_speed_y_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_y_stable"), 0);
                 sv_kinetic_energy!(


### PR DESCRIPTION
More adjustments to be added soon.

# Changelog

## Air Dodge

When performing an air dodge or air dash, your fast fall is canceled.

Air Dash can now grab the ledge after its startup (frame 5) if your fighter is moving downwards.