### PR TITLE
Fix Guard Cancel Buffer

### DIFF
--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -193,8 +193,6 @@ pub mod guard {
     pub mod flag {
         pub const ADD_BUFFER : i32 = 0x1050;
         pub const SET_SHIELD_LOW_SMOKE : i32 = 0x1051;
-        pub const GUARD_CANCEL_ATTACK_OK : i32 = 0x1052;
-        pub const GUARD_CANCEL_TAUNT_OK : i32 = 0x1053;
     }
     pub mod int {
         pub const SHIELD_EFF_ID : i32 = 0x1050;

--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -193,6 +193,8 @@ pub mod guard {
     pub mod flag {
         pub const ADD_BUFFER : i32 = 0x1050;
         pub const SET_SHIELD_LOW_SMOKE : i32 = 0x1051;
+        pub const VALID_GUARD_CANCEL_ATTACK_INPUT : i32 = 0x1052;
+        pub const VALID_GUARD_CANCEL_TAUNT_INPUT : i32 = 0x1053;
     }
     pub mod int {
         pub const SHIELD_EFF_ID : i32 = 0x1050;

--- a/WuBor-Utils/src/vars.rs
+++ b/WuBor-Utils/src/vars.rs
@@ -193,6 +193,8 @@ pub mod guard {
     pub mod flag {
         pub const ADD_BUFFER : i32 = 0x1050;
         pub const SET_SHIELD_LOW_SMOKE : i32 = 0x1051;
+        pub const GUARD_CANCEL_ATTACK_OK : i32 = 0x1052;
+        pub const GUARD_CANCEL_TAUNT_OK : i32 = 0x1053;
     }
     pub mod int {
         pub const SHIELD_EFF_ID : i32 = 0x1050;

--- a/fighters/common/src/status/guard/guard_damage.rs
+++ b/fighters/common/src/status/guard/guard_damage.rs
@@ -467,17 +467,21 @@ unsafe extern "C" fn status_guarddamage_main(fighter: &mut L2CFighterCommon) -> 
             }
         }
         else {
+            let is_shield = ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD);
+            if ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_APPEAL_HI)
+            || ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_APPEAL_S_L)
+            || ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_APPEAL_S_R)
+            || ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_APPEAL_LW) {
+                VarModule::set_flag(fighter.module_accessor, vars::guard::flag::GUARD_CANCEL_TAUNT_OK, is_shield);
+            }
+            if ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL_RAW)
+            && fighter.global_table[STICK_Y].get_f32() == 0.0 {
+                VarModule::set_flag(fighter.module_accessor, vars::guard::flag::GUARD_CANCEL_ATTACK_OK, is_shield);
+            }
             // Guard Cancel Actions
             if !fighter.global_table[IS_STOP].get_bool() && fighter.global_table[STATUS_FRAME].get_f32() > 0.0 {
                 // Guard Cancel Taunt
-                let cat2 = fighter.global_table[CMD_CAT2].get_i32();
-                if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD)
-                && cat2 & (
-                    *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L |
-                    *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R |
-                    *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI |
-                    *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW
-                ) != 0
+                if VarModule::is_flag(fighter.module_accessor, vars::guard::flag::GUARD_CANCEL_TAUNT_OK)
                 && {
                     fighter.clear_lua_stack();
                     lua_args!(fighter, Hash40::new_raw(0x1daca540be));
@@ -490,11 +494,7 @@ unsafe extern "C" fn status_guarddamage_main(fighter: &mut L2CFighterCommon) -> 
 
                 if !VarModule::is_flag(fighter.module_accessor, vars::fighter::instance::flag::BURNOUT) {
                     // Guard Cancel Attack
-                    if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD)
-                    && fighter.global_table[CMD_CAT1].get_i32() & (
-                        *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_N |
-                        *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_S
-                    ) != 0
+                    if VarModule::is_flag(fighter.module_accessor, vars::guard::flag::GUARD_CANCEL_ATTACK_OK)
                     && MotionModule::is_anim_resource(fighter.module_accessor, Hash40::new("guard_cancel_attack")) {
                         fighter.change_status(vars::fighter::status::GUARD_CANCEL_ATTACK.into(), true.into());
                         return 0.into();

--- a/fighters/common/src/status/guard/guard_damage.rs
+++ b/fighters/common/src/status/guard/guard_damage.rs
@@ -467,21 +467,17 @@ unsafe extern "C" fn status_guarddamage_main(fighter: &mut L2CFighterCommon) -> 
             }
         }
         else {
-            let is_shield = ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD);
-            if ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_APPEAL_HI)
-            || ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_APPEAL_S_L)
-            || ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_APPEAL_S_R)
-            || ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_APPEAL_LW) {
-                VarModule::set_flag(fighter.module_accessor, vars::guard::flag::GUARD_CANCEL_TAUNT_OK, is_shield);
-            }
-            if ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL_RAW)
-            && fighter.global_table[STICK_Y].get_f32() == 0.0 {
-                VarModule::set_flag(fighter.module_accessor, vars::guard::flag::GUARD_CANCEL_ATTACK_OK, is_shield);
-            }
             // Guard Cancel Actions
             if !fighter.global_table[IS_STOP].get_bool() && fighter.global_table[STATUS_FRAME].get_f32() > 0.0 {
+                let is_shield = ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD);
                 // Guard Cancel Taunt
-                if VarModule::is_flag(fighter.module_accessor, vars::guard::flag::GUARD_CANCEL_TAUNT_OK)
+                if is_shield
+                && (
+                    ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_APPEAL_HI) ||
+                    ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_APPEAL_S_L) ||
+                    ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_APPEAL_S_R) ||
+                    ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_APPEAL_LW)
+                )
                 && {
                     fighter.clear_lua_stack();
                     lua_args!(fighter, Hash40::new_raw(0x1daca540be));
@@ -494,7 +490,9 @@ unsafe extern "C" fn status_guarddamage_main(fighter: &mut L2CFighterCommon) -> 
 
                 if !VarModule::is_flag(fighter.module_accessor, vars::fighter::instance::flag::BURNOUT) {
                     // Guard Cancel Attack
-                    if VarModule::is_flag(fighter.module_accessor, vars::guard::flag::GUARD_CANCEL_ATTACK_OK)
+                    if is_shield
+                    && ControlModule::check_button_on_trriger(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL_RAW)
+                    && fighter.global_table[STICK_Y].get_f32() == 0.0
                     && MotionModule::is_anim_resource(fighter.module_accessor, Hash40::new("guard_cancel_attack")) {
                         fighter.change_status(vars::fighter::status::GUARD_CANCEL_ATTACK.into(), true.into());
                         return 0.into();

--- a/fighters/common/src/status/guard/guard_damage.rs
+++ b/fighters/common/src/status/guard/guard_damage.rs
@@ -471,7 +471,8 @@ unsafe extern "C" fn status_guarddamage_main(fighter: &mut L2CFighterCommon) -> 
             if !fighter.global_table[IS_STOP].get_bool() && fighter.global_table[STATUS_FRAME].get_f32() > 0.0 {
                 // Guard Cancel Taunt
                 let cat2 = fighter.global_table[CMD_CAT2].get_i32();
-                if cat2 & (
+                if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD)
+                && cat2 & (
                     *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L |
                     *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R |
                     *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI |
@@ -489,7 +490,8 @@ unsafe extern "C" fn status_guarddamage_main(fighter: &mut L2CFighterCommon) -> 
 
                 if !VarModule::is_flag(fighter.module_accessor, vars::fighter::instance::flag::BURNOUT) {
                     // Guard Cancel Attack
-                    if fighter.global_table[CMD_CAT1].get_i32() & (
+                    if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD)
+                    && fighter.global_table[CMD_CAT1].get_i32() & (
                         *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_N |
                         *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_S
                     ) != 0


### PR DESCRIPTION
# Changelog

## Shield
- Guard Cancel Attack and Guard Cancel Taunt can now only be performed if Shield is held.